### PR TITLE
init Math

### DIFF
--- a/examples/math/meson.build
+++ b/examples/math/meson.build
@@ -43,6 +43,10 @@ math_examples = {
 		'src': ['wlf_ray3_test.c'],
 		'dep': [],
 	},
+	'wlf_quaternion_test': {
+		'src': ['wlf_quaternion_test.c'],
+		'dep': [],
+	},
 }
 
 foreach example, info : math_examples

--- a/examples/math/meson.build
+++ b/examples/math/meson.build
@@ -35,6 +35,14 @@ math_examples = {
 		'src': ['wlf_vector4_test.c'],
 		'dep': [],
 	},
+	'wlf_ray2_test': {
+		'src': ['wlf_ray2_test.c'],
+		'dep': [],
+	},
+	'wlf_ray3_test': {
+		'src': ['wlf_ray3_test.c'],
+		'dep': [],
+	},
 }
 
 foreach example, info : math_examples

--- a/examples/math/meson.build
+++ b/examples/math/meson.build
@@ -47,6 +47,10 @@ math_examples = {
 		'src': ['wlf_quaternion_test.c'],
 		'dep': [],
 	},
+	'wlf_matrix3x3_test': {
+		'src': ['wlf_matrix3x3_test.c'],
+		'dep': [],
+	},
 }
 
 foreach example, info : math_examples

--- a/examples/math/meson.build
+++ b/examples/math/meson.build
@@ -55,6 +55,10 @@ math_examples = {
 		'src': ['wlf_matrix4x4_test.c'],
 		'dep': [],
 	},
+	'wlf_region_test': {
+		'src': ['wlf_region_test.c'],
+		'dep': [],
+	},
 }
 
 foreach example, info : math_examples

--- a/examples/math/meson.build
+++ b/examples/math/meson.build
@@ -23,6 +23,10 @@ math_examples = {
 		'src': ['wlf_frect_test.c'],
 		'dep': [],
 	},
+	'wlf_vector2_test': {
+		'src': ['wlf_vector2_test.c'],
+		'dep': [],
+	},
 }
 
 foreach example, info : math_examples

--- a/examples/math/meson.build
+++ b/examples/math/meson.build
@@ -15,6 +15,14 @@ math_examples = {
 		'src': ['wlf_fsize_test.c'],
 		'dep': [],
 	},
+	'wlf_rect_test': {
+		'src': ['wlf_rect_test.c'],
+		'dep': [],
+	},
+	'wlf_frect_test': {
+		'src': ['wlf_frect_test.c'],
+		'dep': [],
+	},
 }
 
 foreach example, info : math_examples

--- a/examples/math/meson.build
+++ b/examples/math/meson.build
@@ -27,6 +27,10 @@ math_examples = {
 		'src': ['wlf_vector2_test.c'],
 		'dep': [],
 	},
+	'wlf_vector3_test': {
+		'src': ['wlf_vector3_test.c'],
+		'dep': [],
+	},
 }
 
 foreach example, info : math_examples

--- a/examples/math/meson.build
+++ b/examples/math/meson.build
@@ -31,6 +31,10 @@ math_examples = {
 		'src': ['wlf_vector3_test.c'],
 		'dep': [],
 	},
+	'wlf_vector4_test': {
+		'src': ['wlf_vector4_test.c'],
+		'dep': [],
+	},
 }
 
 foreach example, info : math_examples

--- a/examples/math/meson.build
+++ b/examples/math/meson.build
@@ -1,0 +1,18 @@
+math_examples = {
+	'wlf_point_test': {
+		'src': ['wlf_point_test.c'],
+		'dep': [],
+	},
+	'wlf_fpoint_test': {
+		'src': ['wlf_fpoint_test.c'],
+		'dep': [],
+	},
+}
+
+foreach example, info : math_examples
+	executable(
+		example,
+		info.get('src', []),
+		dependencies: [wlframe] + info.get('dep', []),
+	)
+endforeach

--- a/examples/math/meson.build
+++ b/examples/math/meson.build
@@ -51,6 +51,10 @@ math_examples = {
 		'src': ['wlf_matrix3x3_test.c'],
 		'dep': [],
 	},
+	'wlf_matrix4x4_test': {
+		'src': ['wlf_matrix4x4_test.c'],
+		'dep': [],
+	},
 }
 
 foreach example, info : math_examples

--- a/examples/math/meson.build
+++ b/examples/math/meson.build
@@ -7,6 +7,14 @@ math_examples = {
 		'src': ['wlf_fpoint_test.c'],
 		'dep': [],
 	},
+	'wlf_size_test': {
+		'src': ['wlf_size_test.c'],
+		'dep': [],
+	},
+	'wlf_fsize_test': {
+		'src': ['wlf_fsize_test.c'],
+		'dep': [],
+	},
 }
 
 foreach example, info : math_examples

--- a/examples/math/wlf_fpoint_test.c
+++ b/examples/math/wlf_fpoint_test.c
@@ -1,0 +1,385 @@
+#include "wlf/math/wlf_fpoint.h"
+#include "wlf/math/wlf_point.h"
+#include "wlf/utils/wlf_log.h"
+
+#include <stdint.h>
+#include <stdlib.h>
+#include <stdio.h>
+#include <math.h>
+
+#ifndef M_PI
+#define M_PI 3.14159265358979323846
+#endif
+
+int main(int argc, char *argv[]) {
+	wlf_log_init(WLF_DEBUG, NULL);
+
+	wlf_log(WLF_INFO, "=== WLF Floating Point Test Suite ===");
+
+	// Test point creation
+	wlf_log(WLF_INFO, "\n--- Testing Floating Point Creation ---");
+	struct wlf_fpoint fp1 = (struct wlf_fpoint){.x = 3.5, .y = 4.7};
+	struct wlf_fpoint fp2 = (struct wlf_fpoint){.x = -2.3, .y = 7.1};
+	struct wlf_fpoint zero_point = (struct wlf_fpoint){.x = 0.0, .y = 0.0};
+
+	char *fp1_str = wlf_fpoint_to_str(&fp1);
+	char *fp2_str = wlf_fpoint_to_str(&fp2);
+	char *zero_str = wlf_fpoint_to_str(&zero_point);
+
+	wlf_log(WLF_INFO, "fp1: %s", fp1_str);
+	wlf_log(WLF_INFO, "fp2: %s", fp2_str);
+	wlf_log(WLF_INFO, "zero: %s", zero_str);
+
+	free(fp1_str);
+	free(fp2_str);
+	free(zero_str);
+
+	// Test precision formatting
+	wlf_log(WLF_INFO, "\n--- Testing Precision Formatting ---");
+	char *prec1_str = wlf_fpoint_to_str_prec(&fp1, 1);
+	char *prec5_str = wlf_fpoint_to_str_prec(&fp1, 5);
+
+	wlf_log(WLF_INFO, "fp1 with 1 decimal: %s", prec1_str);
+	wlf_log(WLF_INFO, "fp1 with 5 decimals: %s", prec5_str);
+
+	free(prec1_str);
+	free(prec5_str);
+
+	// Test constants
+	wlf_log(WLF_INFO, "\n--- Testing Constants ---");
+	char *zero_const_str = wlf_fpoint_to_str(&WLF_FPOINT_ZERO);
+	char *unit_str = wlf_fpoint_to_str(&WLF_FPOINT_UNIT);
+	char *unit_x_str = wlf_fpoint_to_str(&WLF_FPOINT_UNIT_X);
+	char *unit_y_str = wlf_fpoint_to_str(&WLF_FPOINT_UNIT_Y);
+
+	wlf_log(WLF_INFO, "WLF_FPOINT_ZERO: %s", zero_const_str);
+	wlf_log(WLF_INFO, "WLF_FPOINT_UNIT: %s", unit_str);
+	wlf_log(WLF_INFO, "WLF_FPOINT_UNIT_X: %s", unit_x_str);
+	wlf_log(WLF_INFO, "WLF_FPOINT_UNIT_Y: %s", unit_y_str);
+
+	free(zero_const_str);
+	free(unit_str);
+	free(unit_x_str);
+	free(unit_y_str);
+
+	// Test equality
+	wlf_log(WLF_INFO, "\n--- Testing Equality ---");
+	struct wlf_fpoint fp1_copy = (struct wlf_fpoint){.x = 3.5, .y = 4.7};
+	bool exact_equal = wlf_fpoint_equal(&fp1, &fp1_copy);
+	bool not_equal = wlf_fpoint_equal(&fp1, &fp2);
+
+	// Test nearly equal
+	struct wlf_fpoint fp1_nearly = (struct wlf_fpoint){.x = 3.500001, .y = 4.700001};
+	bool nearly_equal = wlf_fpoint_nearly_equal(&fp1, &fp1_nearly, 0.001);
+	bool not_nearly_equal = wlf_fpoint_nearly_equal(&fp1, &fp1_nearly, 0.0000001);
+
+	wlf_log(WLF_INFO, "fp1 == fp1_copy: %s", exact_equal ? "true" : "false");
+	wlf_log(WLF_INFO, "fp1 == fp2: %s", not_equal ? "true" : "false");
+	wlf_log(WLF_INFO, "fp1 nearly equals fp1_nearly (epsilon=0.001): %s", nearly_equal ? "true" : "false");
+	wlf_log(WLF_INFO, "fp1 nearly equals fp1_nearly (epsilon=0.0000001): %s", not_nearly_equal ? "true" : "false");
+
+	// Test zero check
+	wlf_log(WLF_INFO, "\n--- Testing Zero Check ---");
+	bool is_zero = wlf_fpoint_is_zero(&zero_point);
+	bool is_not_zero = wlf_fpoint_is_zero(&fp1);
+	wlf_log(WLF_INFO, "zero_point is zero: %s", is_zero ? "true" : "false");
+	wlf_log(WLF_INFO, "fp1 is zero: %s", is_not_zero ? "true" : "false");
+
+	// Test arithmetic operations
+	wlf_log(WLF_INFO, "\n--- Testing Arithmetic Operations ---");
+	struct wlf_fpoint sum = wlf_fpoint_add(&fp1, &fp2);
+	struct wlf_fpoint diff = wlf_fpoint_subtract(&fp1, &fp2);
+	struct wlf_fpoint scaled = wlf_fpoint_multiply(&fp1, 2.5);
+	struct wlf_fpoint divided = wlf_fpoint_divide(&fp1, 2.0);
+	struct wlf_fpoint negated = wlf_fpoint_negate(&fp1);
+
+	char *sum_str = wlf_fpoint_to_str(&sum);
+	char *diff_str = wlf_fpoint_to_str(&diff);
+	char *scaled_str = wlf_fpoint_to_str(&scaled);
+	char *divided_str = wlf_fpoint_to_str(&divided);
+	char *negated_str = wlf_fpoint_to_str(&negated);
+
+	wlf_log(WLF_INFO, "fp1 + fp2 = %s", sum_str);
+	wlf_log(WLF_INFO, "fp1 - fp2 = %s", diff_str);
+	wlf_log(WLF_INFO, "fp1 * 2.5 = %s", scaled_str);
+	wlf_log(WLF_INFO, "fp1 / 2.0 = %s", divided_str);
+	wlf_log(WLF_INFO, "-fp1 = %s", negated_str);
+
+	free(sum_str);
+	free(diff_str);
+	free(scaled_str);
+	free(divided_str);
+	free(negated_str);
+
+	// Test distance calculations
+	wlf_log(WLF_INFO, "\n--- Testing Distance Calculations ---");
+	double manhattan_dist = wlf_fpoint_manhattan_distance(&fp1, &fp2);
+	double euclidean_dist = wlf_fpoint_euclidean_distance(&fp1, &fp2);
+
+	wlf_log(WLF_INFO, "Manhattan distance between fp1 and fp2: %.3f", manhattan_dist);
+	wlf_log(WLF_INFO, "Euclidean distance between fp1 and fp2: %.3f", euclidean_dist);
+
+	// Test dot product and angle
+	wlf_log(WLF_INFO, "\n--- Testing Dot Product and Angles ---");
+	double dot_product = wlf_fpoint_dot_product(&fp1, &fp2);
+	double fp1_angle = wlf_fpoint_angle(&fp1);
+	double fp2_angle = wlf_fpoint_angle(&fp2);
+	double angle_between = wlf_fpoint_angle_between(&fp1, &fp2);
+
+	wlf_log(WLF_INFO, "Dot product fp1 · fp2: %.3f", dot_product);
+	wlf_log(WLF_INFO, "Angle of fp1: %.3f radians (%.1f degrees)", fp1_angle, fp1_angle * 180.0 / M_PI);
+	wlf_log(WLF_INFO, "Angle of fp2: %.3f radians (%.1f degrees)", fp2_angle, fp2_angle * 180.0 / M_PI);
+	wlf_log(WLF_INFO, "Angle between fp1 and fp2: %.3f radians (%.1f degrees)",
+			angle_between, angle_between * 180.0 / M_PI);
+
+	// Test rotation
+	wlf_log(WLF_INFO, "\n--- Testing Rotation ---");
+	double rotation_angle = M_PI / 4; // 45 degrees
+	struct wlf_fpoint rotated = wlf_fpoint_rotate(&fp1, rotation_angle);
+	char *rotated_str = wlf_fpoint_to_str(&rotated);
+
+	wlf_log(WLF_INFO, "fp1 rotated by 45 degrees: %s", rotated_str);
+	free(rotated_str);
+
+	// Test length calculations
+	wlf_log(WLF_INFO, "\n--- Testing Length Calculations ---");
+	double fp1_length = wlf_fpoint_length(&fp1);
+	double fp1_length_squared = wlf_fpoint_length_squared(&fp1);
+
+	wlf_log(WLF_INFO, "Length of fp1: %.3f", fp1_length);
+	wlf_log(WLF_INFO, "Length squared of fp1: %.3f", fp1_length_squared);
+
+	// Test normalization
+	wlf_log(WLF_INFO, "\n--- Testing Normalization ---");
+	struct wlf_fpoint normalized = wlf_fpoint_normalize(&fp1);
+	double normalized_length = wlf_fpoint_length(&normalized);
+	char *normalized_str = wlf_fpoint_to_str(&normalized);
+
+	wlf_log(WLF_INFO, "Normalized fp1: %s (length: %.6f)", normalized_str, normalized_length);
+	free(normalized_str);
+
+	// Test circle containment
+	wlf_log(WLF_INFO, "\n--- Testing Circle Containment ---");
+	struct wlf_fpoint circle_center = (struct wlf_fpoint){.x = 0.0, .y = 0.0};
+	double radius = 5.0;
+	struct wlf_fpoint inside_point = (struct wlf_fpoint){.x = 3.0, .y = 3.0};
+	struct wlf_fpoint outside_point = (struct wlf_fpoint){.x = 10.0, .y = 10.0};
+
+	bool inside = wlf_fpoint_in_circle(&inside_point, &circle_center, radius);
+	bool outside = wlf_fpoint_in_circle(&outside_point, &circle_center, radius);
+
+	char *inside_str = wlf_fpoint_to_str(&inside_point);
+	char *outside_str = wlf_fpoint_to_str(&outside_point);
+	char *center_str = wlf_fpoint_to_str(&circle_center);
+
+	wlf_log(WLF_INFO, "Point %s in circle (center=%s, radius=%.1f): %s",
+			inside_str, center_str, radius, inside ? "true" : "false");
+	wlf_log(WLF_INFO, "Point %s in circle (center=%s, radius=%.1f): %s",
+			outside_str, center_str, radius, outside ? "true" : "false");
+
+	free(inside_str);
+	free(outside_str);
+	free(center_str);
+
+	// Test rounding operations
+	wlf_log(WLF_INFO, "\n--- Testing Rounding Operations ---");
+	struct wlf_fpoint test_round = (struct wlf_fpoint){.x = 3.7, .y = -2.3};
+	struct wlf_point rounded = wlf_fpoint_round(&test_round);
+	struct wlf_point floored = wlf_fpoint_floor(&test_round);
+	struct wlf_point ceiled = wlf_fpoint_ceil(&test_round);
+
+	char *test_round_str = wlf_fpoint_to_str(&test_round);
+	char *rounded_str = wlf_point_to_str(&rounded);
+	char *floored_str = wlf_point_to_str(&floored);
+	char *ceiled_str = wlf_point_to_str(&ceiled);
+
+	wlf_log(WLF_INFO, "Original: %s", test_round_str);
+	wlf_log(WLF_INFO, "Rounded: %s", rounded_str);
+	wlf_log(WLF_INFO, "Floored: %s", floored_str);
+	wlf_log(WLF_INFO, "Ceiled: %s", ceiled_str);
+
+	free(test_round_str);
+	free(rounded_str);
+	free(floored_str);
+	free(ceiled_str);
+
+	// Test interpolation
+	wlf_log(WLF_INFO, "\n--- Testing Interpolation ---");
+	struct wlf_fpoint start = (struct wlf_fpoint){.x = 0.0, .y = 0.0};
+	struct wlf_fpoint end = (struct wlf_fpoint){.x = 10.0, .y = 10.0};
+	struct wlf_fpoint lerp_half = wlf_fpoint_lerp(&start, &end, 0.5);
+	struct wlf_fpoint lerp_quarter = wlf_fpoint_lerp(&start, &end, 0.25);
+
+	char *start_str = wlf_fpoint_to_str(&start);
+	char *end_str = wlf_fpoint_to_str(&end);
+	char *lerp_half_str = wlf_fpoint_to_str(&lerp_half);
+	char *lerp_quarter_str = wlf_fpoint_to_str(&lerp_quarter);
+
+	wlf_log(WLF_INFO, "Linear interpolation from %s to %s:", start_str, end_str);
+	wlf_log(WLF_INFO, "  At t=0.5: %s", lerp_half_str);
+	wlf_log(WLF_INFO, "  At t=0.25: %s", lerp_quarter_str);
+
+	free(start_str);
+	free(end_str);
+	free(lerp_half_str);
+	free(lerp_quarter_str);
+
+	// Test Bezier curve
+	wlf_log(WLF_INFO, "\n--- Testing Bezier Curve ---");
+	struct wlf_fpoint p0 = (struct wlf_fpoint){.x = 0.0, .y = 0.0};
+	struct wlf_fpoint p1 = (struct wlf_fpoint){.x = 5.0, .y = 10.0};
+	struct wlf_fpoint p2 = (struct wlf_fpoint){.x = 10.0, .y = 0.0};
+	struct wlf_fpoint bezier_half = wlf_fpoint_bezier(&p0, &p1, &p2, 0.5);
+
+	char *p0_str = wlf_fpoint_to_str(&p0);
+	char *p1_str = wlf_fpoint_to_str(&p1);
+	char *p2_str = wlf_fpoint_to_str(&p2);
+	char *bezier_str = wlf_fpoint_to_str(&bezier_half);
+
+	wlf_log(WLF_INFO, "Quadratic Bezier curve:");
+	wlf_log(WLF_INFO, "  P0: %s, P1: %s, P2: %s", p0_str, p1_str, p2_str);
+	wlf_log(WLF_INFO, "  At t=0.5: %s", bezier_str);
+
+	free(p0_str);
+	free(p1_str);
+	free(p2_str);
+	free(bezier_str);
+
+	// Test conversions
+	wlf_log(WLF_INFO, "\n--- Testing Conversions ---");
+	struct wlf_point int_point = (struct wlf_point){.x = 5, .y = 7};
+	struct wlf_fpoint converted_to_float = wlf_point_to_fpoint(&int_point);
+	struct wlf_point converted_back = wlf_fpoint_to_point(&converted_to_float);
+
+	char *int_point_str = wlf_point_to_str(&int_point);
+	char *converted_float_str = wlf_fpoint_to_str(&converted_to_float);
+	char *converted_back_str = wlf_point_to_str(&converted_back);
+
+	wlf_log(WLF_INFO, "Integer point: %s", int_point_str);
+	wlf_log(WLF_INFO, "Converted to float: %s", converted_float_str);
+	wlf_log(WLF_INFO, "Converted back to int: %s", converted_back_str);
+
+	free(int_point_str);
+	free(converted_float_str);
+	free(converted_back_str);
+
+	// Test string parsing
+	wlf_log(WLF_INFO, "\n--- Testing String Parsing ---");
+
+	// Test valid string parsing
+	struct wlf_fpoint parsed_fpoint;
+	bool parse_success;
+
+	// Basic positive floating point numbers
+	parse_success = wlf_fpoint_from_str("(10.5, 20.75)", &parsed_fpoint);
+	char *parsed_str = wlf_fpoint_to_str(&parsed_fpoint);
+	wlf_log(WLF_INFO, "Parse \"(10.5, 20.75)\": %s -> %s",
+			parse_success ? "SUCCESS" : "FAILED", parsed_str);
+	free(parsed_str);
+
+	// Negative floating point numbers
+	parse_success = wlf_fpoint_from_str("(-5.25, 15.0)", &parsed_fpoint);
+	parsed_str = wlf_fpoint_to_str(&parsed_fpoint);
+	wlf_log(WLF_INFO, "Parse \"(-5.25, 15.0)\": %s -> %s",
+			parse_success ? "SUCCESS" : "FAILED", parsed_str);
+	free(parsed_str);
+
+	// With spaces
+	parse_success = wlf_fpoint_from_str("( 100.125 , -200.875 )", &parsed_fpoint);
+	parsed_str = wlf_fpoint_to_str(&parsed_fpoint);
+	wlf_log(WLF_INFO, "Parse \"( 100.125 , -200.875 )\": %s -> %s",
+			parse_success ? "SUCCESS" : "FAILED", parsed_str);
+	free(parsed_str);
+
+	// Zero values
+	parse_success = wlf_fpoint_from_str("(0.0, 0.0)", &parsed_fpoint);
+	parsed_str = wlf_fpoint_to_str(&parsed_fpoint);
+	wlf_log(WLF_INFO, "Parse \"(0.0, 0.0)\": %s -> %s",
+			parse_success ? "SUCCESS" : "FAILED", parsed_str);
+	free(parsed_str);
+
+	// Scientific notation
+	parse_success = wlf_fpoint_from_str("(1.5e2, -3.14e-1)", &parsed_fpoint);
+	parsed_str = wlf_fpoint_to_str(&parsed_fpoint);
+	wlf_log(WLF_INFO, "Parse \"(1.5e2, -3.14e-1)\": %s -> %s",
+			parse_success ? "SUCCESS" : "FAILED", parsed_str);
+	free(parsed_str);
+
+	// Integer values (should work for floating point)
+	parse_success = wlf_fpoint_from_str("(42, -17)", &parsed_fpoint);
+	parsed_str = wlf_fpoint_to_str(&parsed_fpoint);
+	wlf_log(WLF_INFO, "Parse \"(42, -17)\": %s -> %s",
+			parse_success ? "SUCCESS" : "FAILED", parsed_str);
+	free(parsed_str);
+
+	// Test invalid string parsing
+	wlf_log(WLF_INFO, "\n--- Testing Invalid Floating Point String Parsing ---");
+
+	// Missing opening bracket
+	parse_success = wlf_fpoint_from_str("10.5, 20.75)", &parsed_fpoint);
+	wlf_log(WLF_INFO, "Parse \"10.5, 20.75)\": %s (expected: FAILED)",
+			parse_success ? "SUCCESS" : "FAILED");
+
+	// Missing closing bracket
+	parse_success = wlf_fpoint_from_str("(10.5, 20.75", &parsed_fpoint);
+	wlf_log(WLF_INFO, "Parse \"(10.5, 20.75\": %s (expected: FAILED)",
+			parse_success ? "SUCCESS" : "FAILED");
+
+	// Missing comma
+	parse_success = wlf_fpoint_from_str("(10.5 20.75)", &parsed_fpoint);
+	wlf_log(WLF_INFO, "Parse \"(10.5 20.75)\": %s (expected: FAILED)",
+			parse_success ? "SUCCESS" : "FAILED");
+
+	// Invalid characters
+	parse_success = wlf_fpoint_from_str("(abc.def, xyz)", &parsed_fpoint);
+	wlf_log(WLF_INFO, "Parse \"(abc.def, xyz)\": %s (expected: FAILED)",
+			parse_success ? "SUCCESS" : "FAILED");
+
+	// NULL string
+	parse_success = wlf_fpoint_from_str(NULL, &parsed_fpoint);
+	wlf_log(WLF_INFO, "Parse NULL string: %s (expected: FAILED)",
+			parse_success ? "SUCCESS" : "FAILED");
+
+	// NULL point
+	parse_success = wlf_fpoint_from_str("(10.5, 20.75)", NULL);
+	wlf_log(WLF_INFO, "Parse to NULL point: %s (expected: FAILED)",
+			parse_success ? "SUCCESS" : "FAILED");
+
+	// Empty string
+	parse_success = wlf_fpoint_from_str("", &parsed_fpoint);
+	wlf_log(WLF_INFO, "Parse empty string: %s (expected: FAILED)",
+			parse_success ? "SUCCESS" : "FAILED");
+
+	// Test round-trip conversion
+	wlf_log(WLF_INFO, "\n--- Testing Floating Point Round-trip Conversion ---");
+	struct wlf_fpoint original_fp = (struct wlf_fpoint){.x = 3.14159, .y = -2.71828};
+	char *original_fp_str = wlf_fpoint_to_str(&original_fp);
+	struct wlf_fpoint round_trip_fp;
+	bool round_trip_fp_success = wlf_fpoint_from_str(original_fp_str, &round_trip_fp);
+	bool fpoints_equal = wlf_fpoint_nearly_equal(&original_fp, &round_trip_fp, 0.00001);
+
+	char *round_trip_fp_str = wlf_fpoint_to_str(&round_trip_fp);
+	wlf_log(WLF_INFO, "Original: %s", original_fp_str);
+	wlf_log(WLF_INFO, "Round-trip: %s", round_trip_fp_str);
+	wlf_log(WLF_INFO, "Parse success: %s", round_trip_fp_success ? "true" : "false");
+	wlf_log(WLF_INFO, "Points nearly equal: %s", fpoints_equal ? "true" : "false");
+
+	free(original_fp_str);
+	free(round_trip_fp_str);	// Test high precision parsing
+	wlf_log(WLF_INFO, "\n--- Testing High Precision Parsing ---");
+	parse_success = wlf_fpoint_from_str("(3.141592653589793, 2.718281828459045)", &parsed_fpoint);
+	char *high_prec_str = wlf_fpoint_to_str_prec(&parsed_fpoint, 10);
+	wlf_log(WLF_INFO, "High precision parse: %s -> %s",
+			parse_success ? "SUCCESS" : "FAILED", high_prec_str);
+	free(high_prec_str);
+
+	// Normalization of zero vector
+	struct wlf_fpoint zero_normalize = wlf_fpoint_normalize(&zero_point);
+	char *zero_normalize_str = wlf_fpoint_to_str(&zero_normalize);
+	wlf_log(WLF_INFO, "Normalized zero vector: %s", zero_normalize_str);
+	free(zero_normalize_str);
+
+	wlf_log(WLF_INFO, "\n=== Floating Point Test Suite Complete ===");
+
+	return 0;
+}

--- a/examples/math/wlf_frect_test.c
+++ b/examples/math/wlf_frect_test.c
@@ -1,0 +1,344 @@
+#include "wlf/math/wlf_frect.h"
+#include "wlf/utils/wlf_log.h"
+#include <stdlib.h>
+#include <stdint.h>
+#include <math.h>
+
+#ifndef M_PI
+#define M_PI 3.14159265358979323846
+#endif
+
+#ifndef M_E
+#define M_E 2.7182818284590452354
+#endif
+
+int main(int argc, char *argv[]) {
+	wlf_log_init(WLF_DEBUG, NULL);
+
+	wlf_log(WLF_INFO, "=== WLF Floating-Point Rectangle Test Suite ===");
+
+	// Test Rectangle Creation
+	wlf_log(WLF_INFO, "\n--- Testing Floating-Point Rectangle Creation ---");
+
+	struct wlf_frect r1 = wlf_frect_make(10.5, 20.3, 100.7, 80.2);
+	struct wlf_frect r2 = wlf_frect_make(-5.1, -10.8, 50.4, 40.9);
+	struct wlf_frect zero_rect = WLF_FRECT_ZERO;
+	struct wlf_frect unit_rect = WLF_FRECT_UNIT;
+
+	char *str1 = wlf_frect_to_str_prec(&r1, 3);
+	char *str2 = wlf_frect_to_str_prec(&r2, 3);
+	char *str_zero = wlf_frect_to_str_prec(&zero_rect, 1);
+	char *str_unit = wlf_frect_to_str_prec(&unit_rect, 1);
+
+	wlf_log(WLF_INFO, "r1: %s", str1);
+	wlf_log(WLF_INFO, "r2: %s", str2);
+	wlf_log(WLF_INFO, "zero: %s", str_zero);
+	wlf_log(WLF_INFO, "unit: %s", str_unit);
+
+	free(str1); free(str2); free(str_zero); free(str_unit);
+
+	// Test Constants
+	wlf_log(WLF_INFO, "\n--- Testing Constants ---");
+
+	char *zero_str = wlf_frect_to_str_prec(&WLF_FRECT_ZERO, 1);
+	char *unit_str = wlf_frect_to_str_prec(&WLF_FRECT_UNIT, 1);
+	wlf_log(WLF_INFO, "WLF_FRECT_ZERO: %s", zero_str);
+	wlf_log(WLF_INFO, "WLF_FRECT_UNIT: %s", unit_str);
+	free(zero_str); free(unit_str);
+
+	// Test Precision Control
+	wlf_log(WLF_INFO, "\n--- Testing Precision Control ---");
+
+	struct wlf_frect precise = wlf_frect_make(3.141592653589793, 2.718281828459045, 1.414213562373095, 1.732050807568877);
+
+	for (int prec = 0; prec <= 6; prec++) {
+		char *prec_str = wlf_frect_to_str_prec(&precise, prec);
+		wlf_log(WLF_INFO, "Precision %d: %s", prec, prec_str);
+		free(prec_str);
+	}
+
+	// Test Equality
+	wlf_log(WLF_INFO, "\n--- Testing Equality ---");
+
+	struct wlf_frect r1_copy = wlf_frect_make(10.5, 20.3, 100.7, 80.2);
+	struct wlf_frect r1_approx = wlf_frect_make(10.500001, 20.300001, 100.700001, 80.200001);
+
+	wlf_log(WLF_INFO, "r1 == r1_copy (exact): %s", wlf_frect_equal(&r1, &r1_copy) ? "true" : "false");
+	wlf_log(WLF_INFO, "r1 == r2 (exact): %s", wlf_frect_equal(&r1, &r2) ? "true" : "false");
+	wlf_log(WLF_INFO, "r1 ≈ r1_approx (ε=0.001): %s", wlf_frect_nearly_equal(&r1, &r1_approx, 0.001) ? "true" : "false");
+	wlf_log(WLF_INFO, "r1 ≈ r1_approx (ε=0.000001): %s", wlf_frect_nearly_equal(&r1, &r1_approx, 0.000001) ? "true" : "false");
+
+	// Test Conversions
+	wlf_log(WLF_INFO, "\n--- Testing Conversions ---");
+
+	// Integer to floating-point
+	struct wlf_rect int_rect = wlf_rect_make(15, 25, 80, 60);
+	struct wlf_frect from_int = wlf_rect_to_frect(&int_rect);
+
+	char *int_str = wlf_rect_to_str(&int_rect);
+	char *from_int_str = wlf_frect_to_str_prec(&from_int, 1);
+	wlf_log(WLF_INFO, "Integer rect: %s", int_str);
+	wlf_log(WLF_INFO, "To floating-point: %s", from_int_str);
+	free(int_str); free(from_int_str);
+
+	// Floating-point to integer (basic conversion)
+	struct wlf_frect float_rect = wlf_frect_make(10.7, 20.3, 100.9, 80.1);
+	struct wlf_rect to_int = wlf_frect_to_rect(&float_rect);
+
+	char *float_str = wlf_frect_to_str_prec(&float_rect, 1);
+	char *to_int_str = wlf_rect_to_str(&to_int);
+	wlf_log(WLF_INFO, "Floating-point rect: %s", float_str);
+	wlf_log(WLF_INFO, "To integer (truncated): %s", to_int_str);
+	free(float_str); free(to_int_str);
+
+	// Test Rounding Operations
+	wlf_log(WLF_INFO, "\n--- Testing Rounding Operations ---");
+
+	struct wlf_frect test_round = wlf_frect_make(10.3, 20.7, 100.2, 80.8);
+
+	struct wlf_rect rounded = wlf_frect_round(&test_round);
+	struct wlf_rect floored = wlf_frect_floor(&test_round);
+	struct wlf_rect ceiled = wlf_frect_ceil(&test_round);
+
+	char *test_str = wlf_frect_to_str_prec(&test_round, 1);
+	char *round_str = wlf_rect_to_str(&rounded);
+	char *floor_str = wlf_rect_to_str(&floored);
+	char *ceil_str = wlf_rect_to_str(&ceiled);
+
+	wlf_log(WLF_INFO, "Original: %s", test_str);
+	wlf_log(WLF_INFO, "Rounded: %s", round_str);
+	wlf_log(WLF_INFO, "Floored: %s", floor_str);
+	wlf_log(WLF_INFO, "Ceiled: %s", ceil_str);
+
+	free(test_str); free(round_str); free(floor_str); free(ceil_str);
+
+	// Test Specific Rounding Cases
+	wlf_log(WLF_INFO, "\n--- Testing Specific Rounding Cases ---");
+
+	struct wlf_frect edge_cases[] = {
+		wlf_frect_make(0.5, 0.5, 1.5, 1.5),     // exact halves
+		wlf_frect_make(-0.5, -0.5, 2.5, 2.5),   // negative halves
+		wlf_frect_make(0.1, 0.9, 1.1, 1.9),     // close to integers
+		wlf_frect_make(-0.1, -0.9, 2.1, 2.9),   // negative close to integers
+	};
+
+	for (int i = 0; i < 4; i++) {
+		char *orig = wlf_frect_to_str_prec(&edge_cases[i], 1);
+
+		struct wlf_rect r = wlf_frect_round(&edge_cases[i]);
+		struct wlf_rect f = wlf_frect_floor(&edge_cases[i]);
+		struct wlf_rect c = wlf_frect_ceil(&edge_cases[i]);
+
+		char *r_str = wlf_rect_to_str(&r);
+		char *f_str = wlf_rect_to_str(&f);
+		char *c_str = wlf_rect_to_str(&c);
+
+		wlf_log(WLF_INFO, "%s -> Round: %s, Floor: %s, Ceil: %s", orig, r_str, f_str, c_str);
+
+		free(orig); free(r_str); free(f_str); free(c_str);
+	}
+
+	// Test Very Small Numbers
+	wlf_log(WLF_INFO, "\n--- Testing Very Small Numbers ---");
+
+	struct wlf_frect tiny = wlf_frect_make(0.000001, 0.000002, 0.000003, 0.000004);
+	char *tiny_str = wlf_frect_to_str_prec(&tiny, 8);
+	wlf_log(WLF_INFO, "Tiny rectangle: %s", tiny_str);
+	free(tiny_str);
+
+	struct wlf_rect tiny_rounded = wlf_frect_round(&tiny);
+	char *tiny_round_str = wlf_rect_to_str(&tiny_rounded);
+	wlf_log(WLF_INFO, "Tiny rounded: %s", tiny_round_str);
+	free(tiny_round_str);
+
+	// Test Very Large Numbers
+	wlf_log(WLF_INFO, "\n--- Testing Very Large Numbers ---");
+
+	struct wlf_frect large = wlf_frect_make(1000000.5, 2000000.7, 500000.3, 300000.8);
+	char *large_str = wlf_frect_to_str_prec(&large, 1);
+	wlf_log(WLF_INFO, "Large rectangle: %s", large_str);
+	free(large_str);
+
+	struct wlf_rect large_rounded = wlf_frect_round(&large);
+	char *large_round_str = wlf_rect_to_str(&large_rounded);
+	wlf_log(WLF_INFO, "Large rounded: %s", large_round_str);
+	free(large_round_str);
+
+	// Test Negative Coordinates
+	wlf_log(WLF_INFO, "\n--- Testing Negative Coordinates ---");
+
+	struct wlf_frect negative = wlf_frect_make(-10.7, -20.3, 30.9, 40.1);
+	char *neg_str = wlf_frect_to_str_prec(&negative, 1);
+	wlf_log(WLF_INFO, "Negative coordinates: %s", neg_str);
+	free(neg_str);
+
+	struct wlf_rect neg_round = wlf_frect_round(&negative);
+	struct wlf_rect neg_floor = wlf_frect_floor(&negative);
+	struct wlf_rect neg_ceil = wlf_frect_ceil(&negative);
+
+	char *neg_round_str = wlf_rect_to_str(&neg_round);
+	char *neg_floor_str = wlf_rect_to_str(&neg_floor);
+	char *neg_ceil_str = wlf_rect_to_str(&neg_ceil);
+
+	wlf_log(WLF_INFO, "Negative rounded: %s", neg_round_str);
+	wlf_log(WLF_INFO, "Negative floored: %s", neg_floor_str);
+	wlf_log(WLF_INFO, "Negative ceiled: %s", neg_ceil_str);
+
+	free(neg_round_str); free(neg_floor_str); free(neg_ceil_str);
+
+	// Test Round-trip Conversion
+	wlf_log(WLF_INFO, "\n--- Testing Round-trip Conversion ---");
+
+	struct wlf_rect original_int = wlf_rect_make(42, 84, 100, 200);
+	struct wlf_frect converted_float = wlf_rect_to_frect(&original_int);
+	struct wlf_rect back_to_int = wlf_frect_to_rect(&converted_float);
+
+	char *orig_str = wlf_rect_to_str(&original_int);
+	char *conv_str = wlf_frect_to_str_prec(&converted_float, 1);
+	char *back_str = wlf_rect_to_str(&back_to_int);
+
+	wlf_log(WLF_INFO, "Original int: %s", orig_str);
+	wlf_log(WLF_INFO, "To float: %s", conv_str);
+	wlf_log(WLF_INFO, "Back to int: %s", back_str);
+	wlf_log(WLF_INFO, "Round-trip equal: %s", wlf_rect_equal(&original_int, &back_to_int) ? "true" : "false");
+
+	free(orig_str); free(conv_str); free(back_str);
+
+	// Test Mathematical Constants
+	wlf_log(WLF_INFO, "\n--- Testing Mathematical Constants ---");
+
+	struct wlf_frect pi_rect = wlf_frect_make(M_PI, M_E, M_PI/2, M_E/2);
+	char *pi_str = wlf_frect_to_str_prec(&pi_rect, 6);
+	wlf_log(WLF_INFO, "Pi/e rectangle: %s", pi_str);
+	free(pi_str);
+
+	struct wlf_rect pi_rounded = wlf_frect_round(&pi_rect);
+	char *pi_round_str = wlf_rect_to_str(&pi_rounded);
+	wlf_log(WLF_INFO, "Pi/e rounded: %s", pi_round_str);
+	free(pi_round_str);
+
+	// Test Epsilon Comparison Edge Cases
+	wlf_log(WLF_INFO, "\n--- Testing Epsilon Comparison Edge Cases ---");
+
+	struct wlf_frect base = wlf_frect_make(1.0, 2.0, 3.0, 4.0);
+	struct wlf_frect tiny_diff = wlf_frect_make(1.0000001, 2.0000001, 3.0000001, 4.0000001);
+	struct wlf_frect big_diff = wlf_frect_make(1.1, 2.1, 3.1, 4.1);
+
+	double epsilons[] = {1e-10, 1e-6, 1e-3, 0.01, 0.1, 1.0};
+
+	for (int i = 0; i < 6; i++) {
+		double eps = epsilons[i];
+		bool tiny_equal = wlf_frect_nearly_equal(&base, &tiny_diff, eps);
+		bool big_equal = wlf_frect_nearly_equal(&base, &big_diff, eps);
+		wlf_log(WLF_INFO, "ε=%.0e: tiny_diff=%s, big_diff=%s", eps,
+				tiny_equal ? "true" : "false", big_equal ? "true" : "false");
+	}
+
+	// Test Zero and Unit Rectangle Properties
+	wlf_log(WLF_INFO, "\n--- Testing Zero and Unit Rectangle Properties ---");
+
+	struct wlf_rect zero_converted = wlf_frect_to_rect(&WLF_FRECT_ZERO);
+	struct wlf_rect unit_converted = wlf_frect_to_rect(&WLF_FRECT_UNIT);
+
+	char *zero_conv_str = wlf_rect_to_str(&zero_converted);
+	char *unit_conv_str = wlf_rect_to_str(&unit_converted);
+
+	wlf_log(WLF_INFO, "Zero frect to rect: %s", zero_conv_str);
+	wlf_log(WLF_INFO, "Unit frect to rect: %s", unit_conv_str);
+	wlf_log(WLF_INFO, "Zero conversion matches WLF_RECT_ZERO: %s",
+			wlf_rect_equal(&zero_converted, &WLF_RECT_ZERO) ? "true" : "false");
+	wlf_log(WLF_INFO, "Unit conversion matches WLF_RECT_UNIT: %s",
+			wlf_rect_equal(&unit_converted, &WLF_RECT_UNIT) ? "true" : "false");
+
+	free(zero_conv_str); free(unit_conv_str);
+
+	// Test Validity Checks
+	wlf_log(WLF_INFO, "\n--- Testing Validity Checks ---");
+
+	struct wlf_frect valid_rect = wlf_frect_make(10.0, 20.0, 30.5, 40.8);
+	struct wlf_frect invalid_width = wlf_frect_make(10.0, 20.0, -30.5, 40.8);
+	struct wlf_frect invalid_height = wlf_frect_make(10.0, 20.0, 30.5, -40.8);
+	struct wlf_frect zero_width = wlf_frect_make(10.0, 20.0, 0.0, 40.8);
+	struct wlf_frect zero_height = wlf_frect_make(10.0, 20.0, 30.5, 0.0);
+
+	wlf_log(WLF_INFO, "Valid rect (10.0,20.0,30.5,40.8) is valid: %s",
+			wlf_frect_is_valid(&valid_rect) ? "true" : "false");
+	wlf_log(WLF_INFO, "Invalid width rect is valid: %s",
+			wlf_frect_is_valid(&invalid_width) ? "true" : "false");
+	wlf_log(WLF_INFO, "Invalid height rect is valid: %s",
+			wlf_frect_is_valid(&invalid_height) ? "true" : "false");
+	wlf_log(WLF_INFO, "Zero width rect is valid: %s",
+			wlf_frect_is_valid(&zero_width) ? "true" : "false");
+	wlf_log(WLF_INFO, "Zero height rect is valid: %s",
+			wlf_frect_is_valid(&zero_height) ? "true" : "false");
+	wlf_log(WLF_INFO, "NULL pointer is valid: %s",
+			wlf_frect_is_valid(NULL) ? "true" : "false");
+
+	// Test String Parsing
+	wlf_log(WLF_INFO, "\n--- Testing String Parsing ---");
+
+	struct wlf_frect parsed_rect;
+
+	// Test basic format with parentheses (should succeed)
+	if (wlf_frect_from_str("(10.5,20.3,100.7,80.2)", &parsed_rect)) {
+		char *parsed_str = wlf_frect_to_str_prec(&parsed_rect, 3);
+		wlf_log(WLF_INFO, "Parsed '(10.5,20.3,100.7,80.2)': %s", parsed_str);
+		wlf_log(WLF_INFO, "Is valid: %s", wlf_frect_is_valid(&parsed_rect) ? "true" : "false");
+		free(parsed_str);
+	} else {
+		wlf_log(WLF_ERROR, "Failed to parse '(10.5,20.3,100.7,80.2)'");
+	}
+
+	// Test format with spaces and parentheses (should succeed)
+	if (wlf_frect_from_str("(5.1, 15.8, 30.2, 25.9)", &parsed_rect)) {
+		char *parsed_str = wlf_frect_to_str_prec(&parsed_rect, 3);
+		wlf_log(WLF_INFO, "Parsed '(5.1, 15.8, 30.2, 25.9)': %s", parsed_str);
+		free(parsed_str);
+	} else {
+		wlf_log(WLF_ERROR, "Failed to parse '(5.1, 15.8, 30.2, 25.9)'");
+	}
+
+	// Test scientific notation (should succeed)
+	if (wlf_frect_from_str("(1.5e2, 2.3e1, 1.0e3, 8.7e1)", &parsed_rect)) {
+		char *parsed_str = wlf_frect_to_str_prec(&parsed_rect, 3);
+		wlf_log(WLF_INFO, "Parsed scientific notation: %s", parsed_str);
+		free(parsed_str);
+	} else {
+		wlf_log(WLF_ERROR, "Failed to parse scientific notation");
+	}
+
+	// Test negative values with parentheses (should succeed)
+	if (wlf_frect_from_str("(-10.5,-20.8,100.3,80.7)", &parsed_rect)) {
+		char *parsed_str = wlf_frect_to_str_prec(&parsed_rect, 3);
+		wlf_log(WLF_INFO, "Parsed '(-10.5,-20.8,100.3,80.7)': %s", parsed_str);
+		wlf_log(WLF_INFO, "Is valid: %s", wlf_frect_is_valid(&parsed_rect) ? "true" : "false");
+		free(parsed_str);
+	} else {
+		wlf_log(WLF_ERROR, "Failed to parse '(-10.5,-20.8,100.3,80.7)'");
+	}
+
+	// Test integer values (should succeed)
+	if (wlf_frect_from_str("(10,20,30,40)", &parsed_rect)) {
+		char *parsed_str = wlf_frect_to_str_prec(&parsed_rect, 1);
+		wlf_log(WLF_INFO, "Parsed integer format: %s", parsed_str);
+		free(parsed_str);
+	} else {
+		wlf_log(WLF_ERROR, "Failed to parse integer format");
+	}
+
+	// Test invalid formats (should all fail)
+	wlf_log(WLF_INFO, "Testing invalid formats (should all fail):");
+	wlf_log(WLF_INFO, "Empty string: %s", wlf_frect_from_str("", &parsed_rect) ? "parsed" : "failed");
+	wlf_log(WLF_INFO, "NULL string: %s", wlf_frect_from_str(NULL, &parsed_rect) ? "parsed" : "failed");
+	wlf_log(WLF_INFO, "NULL rect: %s", wlf_frect_from_str("(1.0,2.0,3.0,4.0)", NULL) ? "parsed" : "failed");
+	wlf_log(WLF_INFO, "No parentheses: %s", wlf_frect_from_str("10.5,20.3,100.7,80.2", &parsed_rect) ? "parsed" : "failed");
+	wlf_log(WLF_INFO, "Only opening paren: %s", wlf_frect_from_str("(10.5,20.3,100.7,80.2", &parsed_rect) ? "parsed" : "failed");
+	wlf_log(WLF_INFO, "Only closing paren: %s", wlf_frect_from_str("10.5,20.3,100.7,80.2)", &parsed_rect) ? "parsed" : "failed");
+	wlf_log(WLF_INFO, "Invalid format: %s", wlf_frect_from_str("(abc,def,ghi,jkl)", &parsed_rect) ? "parsed" : "failed");
+	wlf_log(WLF_INFO, "Too few values: %s", wlf_frect_from_str("(10.5,20.3,30.1)", &parsed_rect) ? "parsed" : "failed");
+	wlf_log(WLF_INFO, "Extra text after: %s", wlf_frect_from_str("(10.5,20.3,30.1,40.2)extra", &parsed_rect) ? "parsed" : "failed");
+
+	wlf_log(WLF_INFO, "\n=== Floating-Point Rectangle Test Suite Complete ===");
+
+	return 0;
+}

--- a/examples/math/wlf_fsize_test.c
+++ b/examples/math/wlf_fsize_test.c
@@ -1,0 +1,290 @@
+#include "wlf/math/wlf_fsize.h"
+#include "wlf/math/wlf_size.h"
+#include "wlf/utils/wlf_log.h"
+
+#include <stdint.h>
+#include <stdlib.h>
+#include <stdio.h>
+#include <math.h>
+
+#ifndef M_PI
+#define M_PI 3.14159265358979323846
+#endif
+
+int main(int argc, char *argv[]) {
+	wlf_log_init(WLF_DEBUG, NULL);
+
+	wlf_log(WLF_INFO, "=== WLF Floating Point Size Test Suite ===");
+
+	// Test size creation
+	wlf_log(WLF_INFO, "\n--- Testing Floating Point Size Creation ---");
+	struct wlf_fsize fs1 = (struct wlf_fsize) {.width = 800.5, .height = 600.25};
+	struct wlf_fsize fs2 = (struct wlf_fsize) {.width = 1920.0, .height = 1080.0};
+	struct wlf_fsize zero_size = (struct wlf_fsize) {.width = 0.0, .height = 0.0};
+	struct wlf_fsize negative_size = (struct wlf_fsize) {.width = -10.5, .height = 20.75};
+
+	char *fs1_str = wlf_fsize_to_str(&fs1);
+	char *fs2_str = wlf_fsize_to_str(&fs2);
+	char *zero_str = wlf_fsize_to_str(&zero_size);
+	char *negative_str = wlf_fsize_to_str(&negative_size);
+
+	wlf_log(WLF_INFO, "fs1: %s", fs1_str);
+	wlf_log(WLF_INFO, "fs2: %s", fs2_str);
+	wlf_log(WLF_INFO, "zero: %s", zero_str);
+	wlf_log(WLF_INFO, "negative: %s", negative_str);
+
+	free(fs1_str);
+	free(fs2_str);
+	free(zero_str);
+	free(negative_str);
+
+	// Test precision formatting
+	wlf_log(WLF_INFO, "\n--- Testing Precision Formatting ---");
+	char *prec1_str = wlf_fsize_to_str_prec(&fs1, 1);
+	char *prec5_str = wlf_fsize_to_str_prec(&fs1, 5);
+	char *prec0_str = wlf_fsize_to_str_prec(&fs1, 0);
+
+	wlf_log(WLF_INFO, "fs1 with 1 decimal: %s", prec1_str);
+	wlf_log(WLF_INFO, "fs1 with 5 decimals: %s", prec5_str);
+	wlf_log(WLF_INFO, "fs1 with 0 decimals: %s", prec0_str);
+
+	free(prec1_str);
+	free(prec5_str);
+	free(prec0_str);
+
+	// Test constants
+	wlf_log(WLF_INFO, "\n--- Testing Constants ---");
+	char *zero_const_str = wlf_fsize_to_str(&WLF_FSIZE_ZERO);
+	char *unit_str = wlf_fsize_to_str(&WLF_FSIZE_UNIT);
+
+	wlf_log(WLF_INFO, "WLF_FSIZE_ZERO: %s", zero_const_str);
+	wlf_log(WLF_INFO, "WLF_FSIZE_UNIT: %s", unit_str);
+
+	free(zero_const_str);
+	free(unit_str);
+
+	// Test equality
+	wlf_log(WLF_INFO, "\n--- Testing Equality ---");
+	struct wlf_fsize fs1_copy = (struct wlf_fsize) {.width = 800.5, .height = 600.25};
+	bool exact_equal = wlf_fsize_equal(&fs1, &fs1_copy);
+	bool not_equal = wlf_fsize_equal(&fs1, &fs2);
+
+	// Test nearly equal
+	struct wlf_fsize fs1_nearly = (struct wlf_fsize) {.width = 800.500001, .height = 600.250001};
+	bool nearly_equal = wlf_fsize_nearly_equal(&fs1, &fs1_nearly, 0.001);
+	bool not_nearly_equal = wlf_fsize_nearly_equal(&fs1, &fs1_nearly, 0.0000001);
+
+	wlf_log(WLF_INFO, "fs1 == fs1_copy: %s", exact_equal ? "true" : "false");
+	wlf_log(WLF_INFO, "fs1 == fs2: %s", not_equal ? "true" : "false");
+	wlf_log(WLF_INFO, "fs1 nearly equals fs1_nearly (epsilon=0.001): %s",
+		nearly_equal ? "true" : "false");
+	wlf_log(WLF_INFO, "fs1 nearly equals fs1_nearly (epsilon=0.0000001): %s",
+		not_nearly_equal ? "true" : "false");
+
+	// Test arithmetic operations
+	wlf_log(WLF_INFO, "\n--- Testing Arithmetic Operations ---");
+	struct wlf_fsize sum = wlf_fsize_add(&fs1, &fs2);
+	struct wlf_fsize diff = wlf_fsize_subtract(&fs2, &fs1);
+	struct wlf_fsize scaled = wlf_fsize_multiply(&fs1, 2.5);
+	struct wlf_fsize divided = wlf_fsize_divide(&fs1, 2.0);
+
+	char *sum_str = wlf_fsize_to_str(&sum);
+	char *diff_str = wlf_fsize_to_str(&diff);
+	char *scaled_str = wlf_fsize_to_str(&scaled);
+	char *divided_str = wlf_fsize_to_str(&divided);
+
+	wlf_log(WLF_INFO, "fs1 + fs2 = %s", sum_str);
+	wlf_log(WLF_INFO, "fs2 - fs1 = %s", diff_str);
+	wlf_log(WLF_INFO, "fs1 * 2.5 = %s", scaled_str);
+	wlf_log(WLF_INFO, "fs1 / 2.0 = %s", divided_str);
+
+	free(sum_str);
+	free(diff_str);
+	free(scaled_str);
+	free(divided_str);
+
+	// Test area calculation
+	wlf_log(WLF_INFO, "\n--- Testing Area Calculation ---");
+	double fs1_area = wlf_fsize_area(&fs1);
+	double fs2_area = wlf_fsize_area(&fs2);
+	double zero_area = wlf_fsize_area(&zero_size);
+
+	wlf_log(WLF_INFO, "Area of fs1: %.3f", fs1_area);
+	wlf_log(WLF_INFO, "Area of fs2: %.3f", fs2_area);
+	wlf_log(WLF_INFO, "Area of zero size: %.3f", zero_area);
+
+	// Test conversions between integer and floating point sizes
+	wlf_log(WLF_INFO, "\n--- Testing Conversions ---");
+	struct wlf_size int_size = (struct wlf_size) {.width = 640, .height = 480};
+	struct wlf_fsize converted_to_float = wlf_size_to_fsize(&int_size);
+	struct wlf_size converted_back = wlf_fsize_to_size(&converted_to_float);
+
+	char *int_size_str = wlf_size_to_str(&int_size);
+	char *converted_float_str = wlf_fsize_to_str(&converted_to_float);
+	char *converted_back_str = wlf_size_to_str(&converted_back);
+
+	wlf_log(WLF_INFO, "Integer size: %s", int_size_str);
+	wlf_log(WLF_INFO, "Converted to float: %s", converted_float_str);
+	wlf_log(WLF_INFO, "Converted back to int: %s", converted_back_str);
+
+	free(int_size_str);
+	free(converted_float_str);
+	free(converted_back_str);
+
+	// Test rounding operations
+	wlf_log(WLF_INFO, "\n--- Testing Rounding Operations ---");
+	struct wlf_fsize test_round = (struct wlf_fsize) {.width = 123.7, .height = 456.3};
+	struct wlf_size rounded = wlf_fsize_round(&test_round);
+	struct wlf_size floored = wlf_fsize_floor(&test_round);
+	struct wlf_size ceiled = wlf_fsize_ceil(&test_round);
+
+	char *test_round_str = wlf_fsize_to_str(&test_round);
+	char *rounded_str = wlf_size_to_str(&rounded);
+	char *floored_str = wlf_size_to_str(&floored);
+	char *ceiled_str = wlf_size_to_str(&ceiled);
+
+	wlf_log(WLF_INFO, "Original: %s", test_round_str);
+	wlf_log(WLF_INFO, "Rounded: %s", rounded_str);
+	wlf_log(WLF_INFO, "Floored: %s", floored_str);
+	wlf_log(WLF_INFO, "Ceiled: %s", ceiled_str);
+
+	free(test_round_str);
+	free(rounded_str);
+	free(floored_str);
+	free(ceiled_str);
+
+	// Test with fractional values
+	wlf_log(WLF_INFO, "\n--- Testing Fractional Values ---");
+	struct wlf_fsize fractional = (struct wlf_fsize) {.width = 99.99, .height = 199.01};
+	struct wlf_size frac_rounded = wlf_fsize_round(&fractional);
+	struct wlf_size frac_floored = wlf_fsize_floor(&fractional);
+	struct wlf_size frac_ceiled = wlf_fsize_ceil(&fractional);
+
+	char *fractional_str = wlf_fsize_to_str(&fractional);
+	char *frac_rounded_str = wlf_size_to_str(&frac_rounded);
+	char *frac_floored_str = wlf_size_to_str(&frac_floored);
+	char *frac_ceiled_str = wlf_size_to_str(&frac_ceiled);
+
+	wlf_log(WLF_INFO, "Fractional: %s", fractional_str);
+	wlf_log(WLF_INFO, "Rounded: %s", frac_rounded_str);
+	wlf_log(WLF_INFO, "Floored: %s", frac_floored_str);
+	wlf_log(WLF_INFO, "Ceiled: %s", frac_ceiled_str);
+
+	free(fractional_str);
+	free(frac_rounded_str);
+	free(frac_floored_str);
+	free(frac_ceiled_str);
+
+	// Test aspect ratio calculations
+	wlf_log(WLF_INFO, "\n--- Testing Aspect Ratios ---");
+	struct wlf_fsize wide_screen = (struct wlf_fsize) {.width = 1920.0, .height = 1080.0};
+	struct wlf_fsize ultra_wide = (struct wlf_fsize) {.width = 3440.0, .height = 1440.0};
+	struct wlf_fsize square = (struct wlf_fsize) {.width = 1024.0, .height = 1024.0};
+	struct wlf_fsize portrait = (struct wlf_fsize) {.width = 1080.0, .height = 1920.0};
+
+	char *wide_str = wlf_fsize_to_str(&wide_screen);
+	char *ultra_str = wlf_fsize_to_str(&ultra_wide);
+	char *square_str = wlf_fsize_to_str(&square);
+	char *portrait_str = wlf_fsize_to_str(&portrait);
+
+	wlf_log(WLF_INFO, "Wide screen: %s (ratio: %.3f)", wide_str, wide_screen.width / wide_screen.height);
+	wlf_log(WLF_INFO, "Ultra wide: %s (ratio: %.3f)", ultra_str, ultra_wide.width / ultra_wide.height);
+	wlf_log(WLF_INFO, "Square: %s (ratio: %.3f)", square_str, square.width / square.height);
+	wlf_log(WLF_INFO, "Portrait: %s (ratio: %.3f)", portrait_str, portrait.width / portrait.height);
+
+	free(wide_str);
+	free(ultra_str);
+	free(square_str);
+	free(portrait_str);
+
+	// Test scaling with different factors
+	wlf_log(WLF_INFO, "\n--- Testing Various Scaling Factors ---");
+	struct wlf_fsize base = (struct wlf_fsize) {.width = 100.0, .height = 100.0};
+	struct wlf_fsize scaled_pi = wlf_fsize_multiply(&base, M_PI);
+	struct wlf_fsize scaled_half = wlf_fsize_multiply(&base, 0.5);
+	struct wlf_fsize scaled_tiny = wlf_fsize_multiply(&base, 0.001);
+
+	char *base_str = wlf_fsize_to_str(&base);
+	char *scaled_pi_str = wlf_fsize_to_str(&scaled_pi);
+	char *scaled_half_str = wlf_fsize_to_str(&scaled_half);
+	char *scaled_tiny_str = wlf_fsize_to_str(&scaled_tiny);
+
+	wlf_log(WLF_INFO, "Base: %s", base_str);
+	wlf_log(WLF_INFO, "Scaled by π: %s", scaled_pi_str);
+	wlf_log(WLF_INFO, "Scaled by 0.5: %s", scaled_half_str);
+	wlf_log(WLF_INFO, "Scaled by 0.001: %s", scaled_tiny_str);
+
+	free(base_str);
+	free(scaled_pi_str);
+	free(scaled_half_str);
+	free(scaled_tiny_str);
+
+	// Test edge cases
+	wlf_log(WLF_INFO, "\n--- Testing Edge Cases ---");
+
+	// Division by zero
+	struct wlf_fsize div_test = (struct wlf_fsize) {.width = 100.0, .height = 200.0};
+	struct wlf_fsize div_by_zero = wlf_fsize_divide(&div_test, 0.0);
+	char *div_by_zero_str = wlf_fsize_to_str(&div_by_zero);
+	wlf_log(WLF_INFO, "Division by zero result: %s", div_by_zero_str);
+	free(div_by_zero_str);
+
+	// Very small numbers
+	struct wlf_fsize very_small = {.width = 0.00001, .height = 0.00002};
+	char *very_small_str = wlf_fsize_to_str_prec(&very_small, 6);
+	wlf_log(WLF_INFO, "Very small size: %s", very_small_str);
+	free(very_small_str);
+
+	// Very large numbers
+	struct wlf_fsize very_large = (struct wlf_fsize) {.width = 999999.999, .height = 888888.888};
+	char *very_large_str = wlf_fsize_to_str(&very_large);
+	double very_large_area = wlf_fsize_area(&very_large);
+	wlf_log(WLF_INFO, "Very large size: %s (area: %.0f)", very_large_str, very_large_area);
+	free(very_large_str);
+
+	// Negative scaling
+	struct wlf_fsize neg_scaled = wlf_fsize_multiply(&base, -1.5);
+	char *neg_scaled_str = wlf_fsize_to_str(&neg_scaled);
+	wlf_log(WLF_INFO, "Negative scaling: %s", neg_scaled_str);
+	free(neg_scaled_str);
+
+	// Test precision edge cases
+	wlf_log(WLF_INFO, "\n--- Testing Precision Edge Cases ---");
+	struct wlf_fsize precise = (struct wlf_fsize) {.width = 1.23456789, .height = 9.87654321};
+	char *precise_str = wlf_fsize_to_str_prec(&precise, 8);
+	char *precise_str_invalid = wlf_fsize_to_str_prec(&precise, -1); // Should default to 3
+	char *precise_str_large = wlf_fsize_to_str_prec(&precise, 20);   // Should clamp to 15
+
+	wlf_log(WLF_INFO, "High precision (8 decimals): %s", precise_str);
+	wlf_log(WLF_INFO, "Invalid precision (-1): %s", precise_str_invalid);
+	wlf_log(WLF_INFO, "Large precision (20): %s", precise_str_large);
+
+	free(precise_str);
+	free(precise_str_invalid);
+	free(precise_str_large);
+
+	// Test calculations with mixed operations
+	wlf_log(WLF_INFO, "\n--- Testing Complex Calculations ---");
+	struct wlf_fsize calc1 = (struct wlf_fsize) {.width = 10.0, .height = 20.0};
+	struct wlf_fsize calc2 = (struct wlf_fsize) {.width = 5.0, .height = 8.0};
+
+	// Complex calculation: ((calc1 + calc2) * 2.0) / 3.0
+	struct wlf_fsize step1 = wlf_fsize_add(&calc1, &calc2);
+	struct wlf_fsize step2 = wlf_fsize_multiply(&step1, 2.0);
+	struct wlf_fsize result = wlf_fsize_divide(&step2, 3.0);
+
+	char *calc1_str = wlf_fsize_to_str(&calc1);
+	char *calc2_str = wlf_fsize_to_str(&calc2);
+	char *result_str = wlf_fsize_to_str(&result);
+
+	wlf_log(WLF_INFO, "calc1: %s, calc2: %s", calc1_str, calc2_str);
+	wlf_log(WLF_INFO, "((calc1 + calc2) * 2.0) / 3.0 = %s", result_str);
+
+	free(calc1_str);
+	free(calc2_str);
+	free(result_str);
+
+	wlf_log(WLF_INFO, "\n=== Floating Point Size Test Suite Complete ===");
+
+	return 0;
+}

--- a/examples/math/wlf_matrix3x3_test.c
+++ b/examples/math/wlf_matrix3x3_test.c
@@ -1,0 +1,637 @@
+/**
+ * @file        wlf_matrix3x3_test.c
+ * @brief       Comprehensive test suite for wlf_matrix3x3 functionality.
+ * @details     This file provides complete testing coverage for all wlf_matrix3x3
+ *              operations including creation, arithmetic, matrix multiplication,
+ *              transpose, determinant, inversion, and mathematical properties.
+ * @author      Test Suite
+ * @date        2024-12-17
+ * @version     v1.0
+ */
+
+#include "wlf/math/wlf_matrix3x3.h"
+
+#include <stdio.h>
+#include <math.h>
+#include <stdlib.h>
+#include <string.h>
+
+#ifndef M_PI
+#define M_PI 3.14159265358979323846
+#endif
+
+// Test configuration
+static const double EPSILON = 1e-9;
+static int test_count = 0;
+static int passed_tests = 0;
+
+// Function prototypes
+static void print_test_header(const char* test_name);
+static void print_test_summary(void);
+static void test_matrix3x3_creation(void);
+static void test_matrix3x3_basic_operations(void);
+static void test_matrix3x3_arithmetic(void);
+static void test_matrix3x3_matrix_multiplication(void);
+static void test_matrix3x3_transpose(void);
+static void test_matrix3x3_determinant(void);
+static void test_matrix3x3_inverse(void);
+static void test_matrix3x3_equality(void);
+static void test_matrix3x3_edge_cases(void);
+static void test_matrix3x3_mathematical_properties(void);
+static void test_matrix3x3_string_representation(void);
+
+// Test helper functions
+static bool assert_matrix_equal(const struct wlf_matrix3x3 *a, const struct wlf_matrix3x3 *b, double epsilon) {
+	return wlf_matrix3x3_nearly_equal(a, b, epsilon);
+}
+
+// Helper function to compare doubles
+static bool assert_double_equal(double a, double b, double epsilon) {
+	return fabs(a - b) <= epsilon;
+}
+
+static void print_test_header(const char* test_name) {
+	printf("\n=== %s ===\n", test_name);
+}
+
+static void print_test_summary(void) {
+	printf("\n==================================================\n");
+	printf("Test Summary: %d/%d tests passed\n", passed_tests, test_count);
+	if (passed_tests == test_count) {
+		printf("All tests PASSED! ✓\n");
+	} else {
+		printf("%d tests FAILED! ✗\n", test_count - passed_tests);
+	}
+	printf("==================================================\n");
+}
+
+static void test_matrix3x3_creation(void) {
+	print_test_header("Matrix3x3 Creation Tests");
+
+	// Test zero matrix creation
+	test_count++;
+	struct wlf_matrix3x3 zero_matrix = wlf_matrix3x3_create_zero();
+	bool zero_correct = true;
+	for (int i = 0; i < 3; i++) {
+		for (int j = 0; j < 3; j++) {
+			if (zero_matrix.elements[i][j] != 0.0) {
+				zero_correct = false;
+				break;
+			}
+		}
+		if (!zero_correct) break;
+	}
+	if (zero_correct) {
+		printf("✓ Zero matrix creation test passed\n");
+		passed_tests++;
+	} else {
+		printf("✗ Zero matrix creation test failed\n");
+	}
+
+	// Test identity matrix creation
+	test_count++;
+	struct wlf_matrix3x3 identity = wlf_matrix3x3_identity();
+	bool identity_correct = true;
+	for (int i = 0; i < 3; i++) {
+		for (int j = 0; j < 3; j++) {
+			double expected = (i == j) ? 1.0 : 0.0;
+			if (identity.elements[i][j] != expected) {
+				identity_correct = false;
+				break;
+			}
+		}
+		if (!identity_correct) break;
+	}
+	if (identity_correct) {
+		printf("✓ Identity matrix creation test passed\n");
+		passed_tests++;
+	} else {
+		printf("✗ Identity matrix creation test failed\n");
+	}
+}
+
+static void test_matrix3x3_basic_operations(void) {
+	print_test_header("Matrix3x3 Basic Operations Tests");
+
+	// Test get/set operations
+	test_count++;
+	struct wlf_matrix3x3 test_matrix = wlf_matrix3x3_create_zero();
+	wlf_matrix3x3_set(&test_matrix, 0, 0, 1.5);
+	wlf_matrix3x3_set(&test_matrix, 1, 1, 2.5);
+	wlf_matrix3x3_set(&test_matrix, 2, 2, 3.5);
+
+	bool get_set_correct = true;
+	if (!assert_double_equal(wlf_matrix3x3_get(&test_matrix, 0, 0), 1.5, EPSILON) ||
+		!assert_double_equal(wlf_matrix3x3_get(&test_matrix, 1, 1), 2.5, EPSILON) ||
+		!assert_double_equal(wlf_matrix3x3_get(&test_matrix, 2, 2), 3.5, EPSILON)) {
+		get_set_correct = false;
+	}
+
+	if (get_set_correct) {
+		printf("✓ Get/Set operations test passed\n");
+		passed_tests++;
+	} else {
+		printf("✗ Get/Set operations test failed\n");
+	}
+}
+
+static void test_matrix3x3_arithmetic(void) {
+	print_test_header("Matrix3x3 Arithmetic Tests");
+
+	// Create test matrices
+	struct wlf_matrix3x3 matrix_a = wlf_matrix3x3_create_zero();
+	struct wlf_matrix3x3 matrix_b = wlf_matrix3x3_create_zero();
+
+	// Initialize matrix A
+	for (int i = 0; i < 3; i++) {
+		for (int j = 0; j < 3; j++) {
+			matrix_a.elements[i][j] = i * 3 + j + 1; // 1,2,3; 4,5,6; 7,8,9
+		}
+	}
+
+	// Initialize matrix B
+	for (int i = 0; i < 3; i++) {
+		for (int j = 0; j < 3; j++) {
+			matrix_b.elements[i][j] = (i + 1) * (j + 1); // 1,2,3; 2,4,6; 3,6,9
+		}
+	}
+
+	// Test addition
+	test_count++;
+	struct wlf_matrix3x3 sum = wlf_matrix3x3_add(&matrix_a, &matrix_b);
+	struct wlf_matrix3x3 expected_sum = wlf_matrix3x3_create_zero();
+	expected_sum.elements[0][0] = 2; expected_sum.elements[0][1] = 4; expected_sum.elements[0][2] = 6;
+	expected_sum.elements[1][0] = 6; expected_sum.elements[1][1] = 9; expected_sum.elements[1][2] = 12;
+	expected_sum.elements[2][0] = 10; expected_sum.elements[2][1] = 14; expected_sum.elements[2][2] = 18;
+
+	if (assert_matrix_equal(&sum, &expected_sum, EPSILON)) {
+		printf("✓ Matrix addition test passed\n");
+		passed_tests++;
+	} else {
+		printf("✗ Matrix addition test failed\n");
+	}
+
+	// Test subtraction
+	test_count++;
+	struct wlf_matrix3x3 diff = wlf_matrix3x3_subtract(&matrix_a, &matrix_b);
+	struct wlf_matrix3x3 expected_diff = wlf_matrix3x3_create_zero();
+	expected_diff.elements[0][0] = 0; expected_diff.elements[0][1] = 0; expected_diff.elements[0][2] = 0;
+	expected_diff.elements[1][0] = 2; expected_diff.elements[1][1] = 1; expected_diff.elements[1][2] = 0;
+	expected_diff.elements[2][0] = 4; expected_diff.elements[2][1] = 2; expected_diff.elements[2][2] = 0;
+
+	if (assert_matrix_equal(&diff, &expected_diff, EPSILON)) {
+		printf("✓ Matrix subtraction test passed\n");
+		passed_tests++;
+	} else {
+		printf("✗ Matrix subtraction test failed\n");
+	}
+
+	// Test scalar multiplication
+	test_count++;
+	struct wlf_matrix3x3 scaled = wlf_matrix3x3_multiply_scalar(&matrix_a, 2.0);
+	struct wlf_matrix3x3 expected_scaled = wlf_matrix3x3_create_zero();
+	expected_scaled.elements[0][0] = 2; expected_scaled.elements[0][1] = 4; expected_scaled.elements[0][2] = 6;
+	expected_scaled.elements[1][0] = 8; expected_scaled.elements[1][1] = 10; expected_scaled.elements[1][2] = 12;
+	expected_scaled.elements[2][0] = 14; expected_scaled.elements[2][1] = 16; expected_scaled.elements[2][2] = 18;
+
+	if (assert_matrix_equal(&scaled, &expected_scaled, EPSILON)) {
+		printf("✓ Scalar multiplication test passed\n");
+		passed_tests++;
+	} else {
+		printf("✗ Scalar multiplication test failed\n");
+	}
+}
+
+static void test_matrix3x3_matrix_multiplication(void) {
+	print_test_header("Matrix3x3 Matrix Multiplication Tests");
+
+	// Test identity multiplication
+	test_count++;
+	struct wlf_matrix3x3 identity = wlf_matrix3x3_identity();
+	struct wlf_matrix3x3 test_matrix = wlf_matrix3x3_create_zero();
+	test_matrix.elements[0][0] = 1; test_matrix.elements[0][1] = 2; test_matrix.elements[0][2] = 3;
+	test_matrix.elements[1][0] = 4; test_matrix.elements[1][1] = 5; test_matrix.elements[1][2] = 6;
+	test_matrix.elements[2][0] = 7; test_matrix.elements[2][1] = 8; test_matrix.elements[2][2] = 9;
+
+	struct wlf_matrix3x3 result = wlf_matrix3x3_multiply(&identity, &test_matrix);
+
+	if (assert_matrix_equal(&result, &test_matrix, EPSILON)) {
+		printf("✓ Identity multiplication test passed\n");
+		passed_tests++;
+	} else {
+		printf("✗ Identity multiplication test failed\n");
+	}
+
+	// Test specific matrix multiplication
+	test_count++;
+	struct wlf_matrix3x3 matrix_a = wlf_matrix3x3_create_zero();
+	struct wlf_matrix3x3 matrix_b = wlf_matrix3x3_create_zero();
+
+	// A = [[1,2,3], [4,5,6], [7,8,9]]
+	matrix_a.elements[0][0] = 1; matrix_a.elements[0][1] = 2; matrix_a.elements[0][2] = 3;
+	matrix_a.elements[1][0] = 4; matrix_a.elements[1][1] = 5; matrix_a.elements[1][2] = 6;
+	matrix_a.elements[2][0] = 7; matrix_a.elements[2][1] = 8; matrix_a.elements[2][2] = 9;
+
+	// B = [[1,0,0], [0,1,0], [0,0,2]]
+	matrix_b.elements[0][0] = 1; matrix_b.elements[0][1] = 0; matrix_b.elements[0][2] = 0;
+	matrix_b.elements[1][0] = 0; matrix_b.elements[1][1] = 1; matrix_b.elements[1][2] = 0;
+	matrix_b.elements[2][0] = 0; matrix_b.elements[2][1] = 0; matrix_b.elements[2][2] = 2;
+
+	struct wlf_matrix3x3 product = wlf_matrix3x3_multiply(&matrix_a, &matrix_b);
+	struct wlf_matrix3x3 expected_product = wlf_matrix3x3_create_zero();
+	expected_product.elements[0][0] = 1; expected_product.elements[0][1] = 2; expected_product.elements[0][2] = 6;
+	expected_product.elements[1][0] = 4; expected_product.elements[1][1] = 5; expected_product.elements[1][2] = 12;
+	expected_product.elements[2][0] = 7; expected_product.elements[2][1] = 8; expected_product.elements[2][2] = 18;
+
+	if (assert_matrix_equal(&product, &expected_product, EPSILON)) {
+		printf("✓ Matrix multiplication test passed\n");
+		passed_tests++;
+	} else {
+		printf("✗ Matrix multiplication test failed\n");
+	}
+}
+
+static void test_matrix3x3_transpose(void) {
+	print_test_header("Matrix3x3 Transpose Tests");
+
+	// Test transpose
+	test_count++;
+	struct wlf_matrix3x3 matrix = wlf_matrix3x3_create_zero();
+	matrix.elements[0][0] = 1; matrix.elements[0][1] = 2; matrix.elements[0][2] = 3;
+	matrix.elements[1][0] = 4; matrix.elements[1][1] = 5; matrix.elements[1][2] = 6;
+	matrix.elements[2][0] = 7; matrix.elements[2][1] = 8; matrix.elements[2][2] = 9;
+
+	struct wlf_matrix3x3 transposed = wlf_matrix3x3_transpose(&matrix);
+	struct wlf_matrix3x3 expected_transpose = wlf_matrix3x3_create_zero();
+	expected_transpose.elements[0][0] = 1; expected_transpose.elements[0][1] = 4; expected_transpose.elements[0][2] = 7;
+	expected_transpose.elements[1][0] = 2; expected_transpose.elements[1][1] = 5; expected_transpose.elements[1][2] = 8;
+	expected_transpose.elements[2][0] = 3; expected_transpose.elements[2][1] = 6; expected_transpose.elements[2][2] = 9;
+
+	if (assert_matrix_equal(&transposed, &expected_transpose, EPSILON)) {
+		printf("✓ Matrix transpose test passed\n");
+		passed_tests++;
+	} else {
+		printf("✗ Matrix transpose test failed\n");
+	}
+
+	// Test double transpose property: (A^T)^T = A
+	test_count++;
+	struct wlf_matrix3x3 double_transposed = wlf_matrix3x3_transpose(&transposed);
+
+	if (assert_matrix_equal(&double_transposed, &matrix, EPSILON)) {
+		printf("✓ Double transpose property test passed\n");
+		passed_tests++;
+	} else {
+		printf("✗ Double transpose property test failed\n");
+	}
+}
+
+static void test_matrix3x3_determinant(void) {
+	print_test_header("Matrix3x3 Determinant Tests");
+
+	// Test identity matrix determinant
+	test_count++;
+	struct wlf_matrix3x3 identity = wlf_matrix3x3_identity();
+	double det_identity = wlf_matrix3x3_determinant(&identity);
+
+	if (assert_double_equal(det_identity, 1.0, EPSILON)) {
+		printf("✓ Identity matrix determinant test passed\n");
+		passed_tests++;
+	} else {
+		printf("✗ Identity matrix determinant test failed: expected 1.0, got %f\n", det_identity);
+	}
+
+	// Test specific matrix determinant
+	test_count++;
+	struct wlf_matrix3x3 matrix = wlf_matrix3x3_create_zero();
+	matrix.elements[0][0] = 1; matrix.elements[0][1] = 2; matrix.elements[0][2] = 3;
+	matrix.elements[1][0] = 0; matrix.elements[1][1] = 1; matrix.elements[1][2] = 4;
+	matrix.elements[2][0] = 5; matrix.elements[2][1] = 6; matrix.elements[2][2] = 0;
+
+	double det = wlf_matrix3x3_determinant(&matrix);
+	// Expected determinant: 1*(1*0 - 4*6) - 2*(0*0 - 4*5) + 3*(0*6 - 1*5)
+	//                    = 1*(-24) - 2*(-20) + 3*(-5) = -24 + 40 - 15 = 1
+
+	if (assert_double_equal(det, 1.0, EPSILON)) {
+		printf("✓ Matrix determinant test passed\n");
+		passed_tests++;
+	} else {
+		printf("✗ Matrix determinant test failed: expected 1.0, got %f\n", det);
+	}
+
+	// Test zero determinant (singular matrix)
+	test_count++;
+	struct wlf_matrix3x3 singular = wlf_matrix3x3_create_zero();
+	singular.elements[0][0] = 1; singular.elements[0][1] = 2; singular.elements[0][2] = 3;
+	singular.elements[1][0] = 2; singular.elements[1][1] = 4; singular.elements[1][2] = 6;
+	singular.elements[2][0] = 3; singular.elements[2][1] = 6; singular.elements[2][2] = 9;
+
+	double det_singular = wlf_matrix3x3_determinant(&singular);
+
+	if (assert_double_equal(det_singular, 0.0, EPSILON)) {
+		printf("✓ Singular matrix determinant test passed\n");
+		passed_tests++;
+	} else {
+		printf("✗ Singular matrix determinant test failed: expected 0.0, got %f\n", det_singular);
+	}
+}
+
+static void test_matrix3x3_inverse(void) {
+	print_test_header("Matrix3x3 Inverse Tests");
+
+	// Test identity matrix inverse
+	test_count++;
+	struct wlf_matrix3x3 identity = wlf_matrix3x3_identity();
+	struct wlf_matrix3x3 inv_identity = wlf_matrix3x3_inverse(&identity);
+
+	if (assert_matrix_equal(&inv_identity, &identity, EPSILON)) {
+		printf("✓ Identity matrix inverse test passed\n");
+		passed_tests++;
+	} else {
+		printf("✗ Identity matrix inverse test failed\n");
+	}
+
+	// Test specific matrix inverse
+	test_count++;
+	struct wlf_matrix3x3 matrix = wlf_matrix3x3_create_zero();
+	matrix.elements[0][0] = 1; matrix.elements[0][1] = 0; matrix.elements[0][2] = 0;
+	matrix.elements[1][0] = 0; matrix.elements[1][1] = 2; matrix.elements[1][2] = 0;
+	matrix.elements[2][0] = 0; matrix.elements[2][1] = 0; matrix.elements[2][2] = 3;
+
+	struct wlf_matrix3x3 inverse = wlf_matrix3x3_inverse(&matrix);
+	struct wlf_matrix3x3 expected_inverse = wlf_matrix3x3_create_zero();
+	expected_inverse.elements[0][0] = 1; expected_inverse.elements[0][1] = 0; expected_inverse.elements[0][2] = 0;
+	expected_inverse.elements[1][0] = 0; expected_inverse.elements[1][1] = 0.5; expected_inverse.elements[1][2] = 0;
+	expected_inverse.elements[2][0] = 0; expected_inverse.elements[2][1] = 0; expected_inverse.elements[2][2] = 1.0/3.0;
+
+	if (assert_matrix_equal(&inverse, &expected_inverse, EPSILON)) {
+		printf("✓ Matrix inverse test passed\n");
+		passed_tests++;
+	} else {
+		printf("✗ Matrix inverse test failed\n");
+	}
+
+	// Test A * A^-1 = I
+	test_count++;
+	struct wlf_matrix3x3 product = wlf_matrix3x3_multiply(&matrix, &inverse);
+
+	if (assert_matrix_equal(&product, &identity, EPSILON)) {
+		printf("✓ Matrix inverse property test passed\n");
+		passed_tests++;
+	} else {
+		printf("✗ Matrix inverse property test failed\n");
+	}
+
+	// Test singular matrix inverse (should return zero matrix)
+	test_count++;
+	struct wlf_matrix3x3 singular = wlf_matrix3x3_create_zero();
+	singular.elements[0][0] = 1; singular.elements[0][1] = 2; singular.elements[0][2] = 3;
+	singular.elements[1][0] = 2; singular.elements[1][1] = 4; singular.elements[1][2] = 6;
+	singular.elements[2][0] = 3; singular.elements[2][1] = 6; singular.elements[2][2] = 9;
+
+	struct wlf_matrix3x3 inv_singular = wlf_matrix3x3_inverse(&singular);
+	struct wlf_matrix3x3 zero_matrix = wlf_matrix3x3_create_zero();
+
+	if (assert_matrix_equal(&inv_singular, &zero_matrix, EPSILON)) {
+		printf("✓ Singular matrix inverse test passed\n");
+		passed_tests++;
+	} else {
+		printf("✗ Singular matrix inverse test failed\n");
+	}
+}
+
+static void test_matrix3x3_equality(void) {
+	print_test_header("Matrix3x3 Equality Tests");
+
+	// Test exact equality
+	test_count++;
+	struct wlf_matrix3x3 matrix_a = wlf_matrix3x3_identity();
+	struct wlf_matrix3x3 matrix_b = wlf_matrix3x3_identity();
+
+	if (wlf_matrix3x3_equal(&matrix_a, &matrix_b)) {
+		printf("✓ Exact equality test passed\n");
+		passed_tests++;
+	} else {
+		printf("✗ Exact equality test failed\n");
+	}
+
+	// Test inequality
+	test_count++;
+	matrix_b.elements[0][0] = 2.0;
+
+	if (!wlf_matrix3x3_equal(&matrix_a, &matrix_b)) {
+		printf("✓ Inequality test passed\n");
+		passed_tests++;
+	} else {
+		printf("✗ Inequality test failed\n");
+	}
+
+	// Test nearly equal
+	test_count++;
+	matrix_b.elements[0][0] = 1.0 + EPSILON / 2;
+
+	if (wlf_matrix3x3_nearly_equal(&matrix_a, &matrix_b, EPSILON)) {
+		printf("✓ Nearly equal test passed\n");
+		passed_tests++;
+	} else {
+		printf("✗ Nearly equal test failed\n");
+	}
+
+	// Test not nearly equal
+	test_count++;
+	matrix_b.elements[0][0] = 1.0 + EPSILON * 2;
+
+	if (!wlf_matrix3x3_nearly_equal(&matrix_a, &matrix_b, EPSILON)) {
+		printf("✓ Not nearly equal test passed\n");
+		passed_tests++;
+	} else {
+		printf("✗ Not nearly equal test failed\n");
+	}
+}
+
+static void test_matrix3x3_mathematical_properties(void) {
+	print_test_header("Matrix3x3 Mathematical Properties Tests");
+
+	// Create test matrices
+	struct wlf_matrix3x3 a = wlf_matrix3x3_create_zero();
+	struct wlf_matrix3x3 b = wlf_matrix3x3_create_zero();
+	struct wlf_matrix3x3 c = wlf_matrix3x3_create_zero();
+
+	// Initialize matrices with non-trivial values
+	a.elements[0][0] = 1; a.elements[0][1] = 2; a.elements[0][2] = 0;
+	a.elements[1][0] = 3; a.elements[1][1] = 1; a.elements[1][2] = 1;
+	a.elements[2][0] = 0; a.elements[2][1] = 1; a.elements[2][2] = 2;
+
+	b.elements[0][0] = 2; b.elements[0][1] = 1; b.elements[0][2] = 1;
+	b.elements[1][0] = 0; b.elements[1][1] = 1; b.elements[1][2] = 0;
+	b.elements[2][0] = 1; b.elements[2][1] = 0; b.elements[2][2] = 1;
+
+	c.elements[0][0] = 1; c.elements[0][1] = 0; c.elements[0][2] = 2;
+	c.elements[1][0] = 0; c.elements[1][1] = 2; c.elements[1][2] = 1;
+	c.elements[2][0] = 1; c.elements[2][1] = 1; c.elements[2][2] = 0;
+
+	// Test commutative property of addition: A + B = B + A
+	test_count++;
+	struct wlf_matrix3x3 ab_sum = wlf_matrix3x3_add(&a, &b);
+	struct wlf_matrix3x3 ba_sum = wlf_matrix3x3_add(&b, &a);
+
+	if (assert_matrix_equal(&ab_sum, &ba_sum, EPSILON)) {
+		printf("✓ Addition commutativity test passed\n");
+		passed_tests++;
+	} else {
+		printf("✗ Addition commutativity test failed\n");
+	}
+
+	// Test associative property of addition: (A + B) + C = A + (B + C)
+	test_count++;
+	struct wlf_matrix3x3 ab_c = wlf_matrix3x3_add(&ab_sum, &c);
+	struct wlf_matrix3x3 bc_sum = wlf_matrix3x3_add(&b, &c);
+	struct wlf_matrix3x3 a_bc = wlf_matrix3x3_add(&a, &bc_sum);
+
+	if (assert_matrix_equal(&ab_c, &a_bc, EPSILON)) {
+		printf("✓ Addition associativity test passed\n");
+		passed_tests++;
+	} else {
+		printf("✗ Addition associativity test failed\n");
+	}
+
+	// Test associative property of multiplication: (A * B) * C = A * (B * C)
+	test_count++;
+	struct wlf_matrix3x3 ab_mult = wlf_matrix3x3_multiply(&a, &b);
+	struct wlf_matrix3x3 ab_c_mult = wlf_matrix3x3_multiply(&ab_mult, &c);
+	struct wlf_matrix3x3 bc_mult = wlf_matrix3x3_multiply(&b, &c);
+	struct wlf_matrix3x3 a_bc_mult = wlf_matrix3x3_multiply(&a, &bc_mult);
+
+	if (assert_matrix_equal(&ab_c_mult, &a_bc_mult, EPSILON)) {
+		printf("✓ Multiplication associativity test passed\n");
+		passed_tests++;
+	} else {
+		printf("✗ Multiplication associativity test failed\n");
+	}
+
+	// Test distributive property: A * (B + C) = A * B + A * C
+	test_count++;
+	struct wlf_matrix3x3 bc_add = wlf_matrix3x3_add(&b, &c);
+	struct wlf_matrix3x3 a_bc_add = wlf_matrix3x3_multiply(&a, &bc_add);
+	struct wlf_matrix3x3 ac_mult = wlf_matrix3x3_multiply(&a, &c);
+	struct wlf_matrix3x3 ab_ac_add = wlf_matrix3x3_add(&ab_mult, &ac_mult);
+
+	if (assert_matrix_equal(&a_bc_add, &ab_ac_add, EPSILON)) {
+		printf("✓ Distributive property test passed\n");
+		passed_tests++;
+	} else {
+		printf("✗ Distributive property test failed\n");
+	}
+
+	// Test transpose of product: (A * B)^T = B^T * A^T
+	test_count++;
+	struct wlf_matrix3x3 ab_transpose = wlf_matrix3x3_transpose(&ab_mult);
+	struct wlf_matrix3x3 b_transpose = wlf_matrix3x3_transpose(&b);
+	struct wlf_matrix3x3 a_transpose = wlf_matrix3x3_transpose(&a);
+	struct wlf_matrix3x3 bt_at = wlf_matrix3x3_multiply(&b_transpose, &a_transpose);
+
+	if (assert_matrix_equal(&ab_transpose, &bt_at, EPSILON)) {
+		printf("✓ Transpose of product property test passed\n");
+		passed_tests++;
+	} else {
+		printf("✗ Transpose of product property test failed\n");
+	}
+}
+
+static void test_matrix3x3_edge_cases(void) {
+	print_test_header("Matrix3x3 Edge Cases Tests");
+
+	// Test with very small numbers
+	test_count++;
+	struct wlf_matrix3x3 small_matrix = wlf_matrix3x3_create_zero();
+	small_matrix.elements[0][0] = 1e-10;
+	small_matrix.elements[1][1] = 1e-10;
+	small_matrix.elements[2][2] = 1e-10;
+
+	double det_small = wlf_matrix3x3_determinant(&small_matrix);
+
+	if (assert_double_equal(det_small, 1e-30, 1e-35)) {
+		printf("✓ Small numbers test passed\n");
+		passed_tests++;
+	} else {
+		printf("✗ Small numbers test failed: expected ~1e-30, got %e\n", det_small);
+	}
+
+	// Test with large numbers
+	test_count++;
+	struct wlf_matrix3x3 large_matrix = wlf_matrix3x3_create_zero();
+	large_matrix.elements[0][0] = 1e6;
+	large_matrix.elements[1][1] = 1e6;
+	large_matrix.elements[2][2] = 1e6;
+
+	double det_large = wlf_matrix3x3_determinant(&large_matrix);
+
+	if (assert_double_equal(det_large, 1e18, 1e12)) {
+		printf("✓ Large numbers test passed\n");
+		passed_tests++;
+	} else {
+		printf("✗ Large numbers test failed: expected ~1e18, got %e\n", det_large);
+	}
+
+	// Test negative values
+	test_count++;
+	struct wlf_matrix3x3 negative_matrix = wlf_matrix3x3_create_zero();
+	negative_matrix.elements[0][0] = -1; negative_matrix.elements[0][1] = 2; negative_matrix.elements[0][2] = -3;
+	negative_matrix.elements[1][0] = 4; negative_matrix.elements[1][1] = -5; negative_matrix.elements[1][2] = 6;
+	negative_matrix.elements[2][0] = -7; negative_matrix.elements[2][1] = 8; negative_matrix.elements[2][2] = -9;
+
+	struct wlf_matrix3x3 scaled_negative = wlf_matrix3x3_multiply_scalar(&negative_matrix, -1.0);
+	struct wlf_matrix3x3 positive_matrix = wlf_matrix3x3_create_zero();
+	positive_matrix.elements[0][0] = 1; positive_matrix.elements[0][1] = -2; positive_matrix.elements[0][2] = 3;
+	positive_matrix.elements[1][0] = -4; positive_matrix.elements[1][1] = 5; positive_matrix.elements[1][2] = -6;
+	positive_matrix.elements[2][0] = 7; positive_matrix.elements[2][1] = -8; positive_matrix.elements[2][2] = 9;
+
+	if (assert_matrix_equal(&scaled_negative, &positive_matrix, EPSILON)) {
+		printf("✓ Negative values test passed\n");
+		passed_tests++;
+	} else {
+		printf("✗ Negative values test failed\n");
+	}
+}
+
+static void test_matrix3x3_string_representation(void) {
+	print_test_header("Matrix3x3 String Representation Tests");
+
+	test_count++;
+	struct wlf_matrix3x3 matrix = wlf_matrix3x3_identity();
+	char* str_repr = wlf_matrix3x3_to_str(&matrix);
+
+	bool string_valid = (str_repr != NULL && strlen(str_repr) > 0);
+
+	if (string_valid) {
+		printf("✓ String representation test passed\n");
+		printf("  Matrix string: %s\n", str_repr);
+		passed_tests++;
+	} else {
+		printf("✗ String representation test failed\n");
+	}
+
+	if (str_repr) {
+		free(str_repr);
+	}
+}
+
+int main(void) {
+	printf("Starting comprehensive wlf_matrix3x3 test suite...\n");
+
+	test_matrix3x3_creation();
+	test_matrix3x3_basic_operations();
+	test_matrix3x3_arithmetic();
+	test_matrix3x3_matrix_multiplication();
+	test_matrix3x3_transpose();
+	test_matrix3x3_determinant();
+	test_matrix3x3_inverse();
+	test_matrix3x3_equality();
+	test_matrix3x3_mathematical_properties();
+	test_matrix3x3_edge_cases();
+	test_matrix3x3_string_representation();
+
+	print_test_summary();
+
+	return (passed_tests == test_count) ? 0 : 1;
+}

--- a/examples/math/wlf_matrix4x4_test.c
+++ b/examples/math/wlf_matrix4x4_test.c
@@ -1,0 +1,640 @@
+/**
+ * @file        wlf_matrix4x4_test.c
+ * @brief       Comprehensive test suite for wlf_matrix4x4 functionality.
+ * @details     This file provides complete testing coverage for all wlf_matrix4x4
+ *              operations including creation, arithmetic, matrix multiplication,
+ *              transpose, determinant, inversion, and mathematical properties.
+ * @author      Test Suite
+ * @date        2024-12-17
+ * @version     v1.0
+ */
+
+#include "wlf/math/wlf_matrix4x4.h"
+
+#include <stdio.h>
+#include <math.h>
+#include <stdlib.h>
+#include <string.h>
+
+#ifndef M_PI
+#define M_PI 3.14159265358979323846
+#endif
+
+// Test configuration
+static const double EPSILON = 1e-9;
+static int test_count = 0;
+static int passed_tests = 0;
+
+// Function prototypes
+static void print_test_header(const char* test_name);
+static void print_test_summary(void);
+static void test_matrix4x4_creation(void);
+static void test_matrix4x4_basic_operations(void);
+static void test_matrix4x4_arithmetic(void);
+static void test_matrix4x4_matrix_multiplication(void);
+static void test_matrix4x4_transpose(void);
+static void test_matrix4x4_determinant(void);
+static void test_matrix4x4_inverse(void);
+static void test_matrix4x4_equality(void);
+static void test_matrix4x4_edge_cases(void);
+static void test_matrix4x4_mathematical_properties(void);
+static void test_matrix4x4_string_representation(void);
+
+// Test helper functions
+static bool assert_matrix_equal(const struct wlf_matrix4x4 *a, const struct wlf_matrix4x4 *b, double epsilon) {
+	return wlf_matrix4x4_nearly_equal(a, b, epsilon);
+}
+
+// Helper function to compare doubles
+static bool assert_double_equal(double a, double b, double epsilon) {
+	return fabs(a - b) <= epsilon;
+}
+
+static void print_test_header(const char* test_name) {
+	printf("\n=== %s ===\n", test_name);
+}
+
+static void print_test_summary(void) {
+	printf("\n==================================================\n");
+	printf("Test Summary: %d/%d tests passed\n", passed_tests, test_count);
+	if (passed_tests == test_count) {
+		printf("All tests PASSED! ✓\n");
+	} else {
+		printf("%d tests FAILED! ✗\n", test_count - passed_tests);
+	}
+	printf("==================================================\n");
+}
+
+static void test_matrix4x4_creation(void) {
+	print_test_header("Matrix4x4 Creation Tests");
+
+	// Test zero matrix creation
+	test_count++;
+	struct wlf_matrix4x4 zero_matrix = wlf_matrix4x4_create_zero();
+	bool zero_correct = true;
+	for (int i = 0; i < 4; i++) {
+		for (int j = 0; j < 4; j++) {
+			if (zero_matrix.elements[i][j] != 0.0) {
+				zero_correct = false;
+				break;
+			}
+		}
+		if (!zero_correct) break;
+	}
+	if (zero_correct) {
+		printf("✓ Zero matrix creation test passed\n");
+		passed_tests++;
+	} else {
+		printf("✗ Zero matrix creation test failed\n");
+	}
+
+	// Test identity matrix creation
+	test_count++;
+	struct wlf_matrix4x4 identity = wlf_matrix4x4_identity();
+	bool identity_correct = true;
+	for (int i = 0; i < 4; i++) {
+		for (int j = 0; j < 4; j++) {
+			double expected = (i == j) ? 1.0 : 0.0;
+			if (identity.elements[i][j] != expected) {
+				identity_correct = false;
+				break;
+			}
+		}
+		if (!identity_correct) break;
+	}
+	if (identity_correct) {
+		printf("✓ Identity matrix creation test passed\n");
+		passed_tests++;
+	} else {
+		printf("✗ Identity matrix creation test failed\n");
+	}
+}
+
+static void test_matrix4x4_basic_operations(void) {
+	print_test_header("Matrix4x4 Basic Operations Tests");
+
+	// Test get/set operations
+	test_count++;
+	struct wlf_matrix4x4 test_matrix = wlf_matrix4x4_create_zero();
+	wlf_matrix4x4_set(&test_matrix, 0, 0, 1.5);
+	wlf_matrix4x4_set(&test_matrix, 1, 1, 2.5);
+	wlf_matrix4x4_set(&test_matrix, 2, 2, 3.5);
+	wlf_matrix4x4_set(&test_matrix, 3, 3, 4.5);
+
+	bool get_set_correct = true;
+	if (!assert_double_equal(wlf_matrix4x4_get(&test_matrix, 0, 0), 1.5, EPSILON) ||
+		!assert_double_equal(wlf_matrix4x4_get(&test_matrix, 1, 1), 2.5, EPSILON) ||
+		!assert_double_equal(wlf_matrix4x4_get(&test_matrix, 2, 2), 3.5, EPSILON) ||
+		!assert_double_equal(wlf_matrix4x4_get(&test_matrix, 3, 3), 4.5, EPSILON)) {
+		get_set_correct = false;
+	}
+
+	if (get_set_correct) {
+		printf("✓ Get/Set operations test passed\n");
+		passed_tests++;
+	} else {
+		printf("✗ Get/Set operations test failed\n");
+	}
+}
+
+static void test_matrix4x4_arithmetic(void) {
+	print_test_header("Matrix4x4 Arithmetic Tests");
+
+	// Create test matrices
+	struct wlf_matrix4x4 matrix_a = wlf_matrix4x4_create_zero();
+	struct wlf_matrix4x4 matrix_b = wlf_matrix4x4_create_zero();
+
+	// Initialize matrix A
+	for (int i = 0; i < 4; i++) {
+		for (int j = 0; j < 4; j++) {
+			matrix_a.elements[i][j] = i * 4 + j + 1; // 1,2,3,4; 5,6,7,8; 9,10,11,12; 13,14,15,16
+		}
+	}
+
+	// Initialize matrix B
+	for (int i = 0; i < 4; i++) {
+		for (int j = 0; j < 4; j++) {
+			matrix_b.elements[i][j] = (i + 1) * (j + 1); // 1,2,3,4; 2,4,6,8; 3,6,9,12; 4,8,12,16
+		}
+	}
+
+	// Test addition
+	test_count++;
+	struct wlf_matrix4x4 sum = wlf_matrix4x4_add(&matrix_a, &matrix_b);
+	struct wlf_matrix4x4 expected_sum = wlf_matrix4x4_create_zero();
+	expected_sum.elements[0][0] = 2; expected_sum.elements[0][1] = 4; expected_sum.elements[0][2] = 6; expected_sum.elements[0][3] = 8;
+	expected_sum.elements[1][0] = 7; expected_sum.elements[1][1] = 10; expected_sum.elements[1][2] = 13; expected_sum.elements[1][3] = 16;
+	expected_sum.elements[2][0] = 12; expected_sum.elements[2][1] = 16; expected_sum.elements[2][2] = 20; expected_sum.elements[2][3] = 24;
+	expected_sum.elements[3][0] = 17; expected_sum.elements[3][1] = 22; expected_sum.elements[3][2] = 27; expected_sum.elements[3][3] = 32;
+
+	if (assert_matrix_equal(&sum, &expected_sum, EPSILON)) {
+		printf("✓ Matrix addition test passed\n");
+		passed_tests++;
+	} else {
+		printf("✗ Matrix addition test failed\n");
+	}
+
+	// Test subtraction
+	test_count++;
+	struct wlf_matrix4x4 diff = wlf_matrix4x4_subtract(&matrix_a, &matrix_b);
+	struct wlf_matrix4x4 expected_diff = wlf_matrix4x4_create_zero();
+	expected_diff.elements[0][0] = 0; expected_diff.elements[0][1] = 0; expected_diff.elements[0][2] = 0; expected_diff.elements[0][3] = 0;
+	expected_diff.elements[1][0] = 3; expected_diff.elements[1][1] = 2; expected_diff.elements[1][2] = 1; expected_diff.elements[1][3] = 0;
+	expected_diff.elements[2][0] = 6; expected_diff.elements[2][1] = 4; expected_diff.elements[2][2] = 2; expected_diff.elements[2][3] = 0;
+	expected_diff.elements[3][0] = 9; expected_diff.elements[3][1] = 6; expected_diff.elements[3][2] = 3; expected_diff.elements[3][3] = 0;
+
+	if (assert_matrix_equal(&diff, &expected_diff, EPSILON)) {
+		printf("✓ Matrix subtraction test passed\n");
+		passed_tests++;
+	} else {
+		printf("✗ Matrix subtraction test failed\n");
+	}
+
+	// Test scalar multiplication
+	test_count++;
+	struct wlf_matrix4x4 scaled = wlf_matrix4x4_multiply_scalar(&matrix_a, 2.0);
+	struct wlf_matrix4x4 expected_scaled = wlf_matrix4x4_create_zero();
+	expected_scaled.elements[0][0] = 2; expected_scaled.elements[0][1] = 4; expected_scaled.elements[0][2] = 6; expected_scaled.elements[0][3] = 8;
+	expected_scaled.elements[1][0] = 10; expected_scaled.elements[1][1] = 12; expected_scaled.elements[1][2] = 14; expected_scaled.elements[1][3] = 16;
+	expected_scaled.elements[2][0] = 18; expected_scaled.elements[2][1] = 20; expected_scaled.elements[2][2] = 22; expected_scaled.elements[2][3] = 24;
+	expected_scaled.elements[3][0] = 26; expected_scaled.elements[3][1] = 28; expected_scaled.elements[3][2] = 30; expected_scaled.elements[3][3] = 32;
+
+	if (assert_matrix_equal(&scaled, &expected_scaled, EPSILON)) {
+		printf("✓ Scalar multiplication test passed\n");
+		passed_tests++;
+	} else {
+		printf("✗ Scalar multiplication test failed\n");
+	}
+}
+
+static void test_matrix4x4_matrix_multiplication(void) {
+	print_test_header("Matrix4x4 Matrix Multiplication Tests");
+
+	// Test identity matrix multiplication
+	test_count++;
+	struct wlf_matrix4x4 identity = wlf_matrix4x4_identity();
+	struct wlf_matrix4x4 test_matrix = wlf_matrix4x4_create_zero();
+	for (int i = 0; i < 4; i++) {
+		for (int j = 0; j < 4; j++) {
+			test_matrix.elements[i][j] = i * 4 + j + 1;
+		}
+	}
+
+	struct wlf_matrix4x4 product1 = wlf_matrix4x4_multiply(&identity, &test_matrix);
+	struct wlf_matrix4x4 product2 = wlf_matrix4x4_multiply(&test_matrix, &identity);
+
+	if (assert_matrix_equal(&product1, &test_matrix, EPSILON) &&
+		assert_matrix_equal(&product2, &test_matrix, EPSILON)) {
+		printf("✓ Identity matrix multiplication test passed\n");
+		passed_tests++;
+	} else {
+		printf("✗ Identity matrix multiplication test failed\n");
+	}
+
+	// Test simple matrix multiplication
+	test_count++;
+	struct wlf_matrix4x4 matrix_a = wlf_matrix4x4_create_zero();
+	struct wlf_matrix4x4 matrix_b = wlf_matrix4x4_create_zero();
+
+	// Create simple matrices for multiplication
+	matrix_a.elements[0][0] = 1; matrix_a.elements[0][1] = 2; matrix_a.elements[0][2] = 0; matrix_a.elements[0][3] = 0;
+	matrix_a.elements[1][0] = 3; matrix_a.elements[1][1] = 4; matrix_a.elements[1][2] = 0; matrix_a.elements[1][3] = 0;
+	matrix_a.elements[2][0] = 0; matrix_a.elements[2][1] = 0; matrix_a.elements[2][2] = 1; matrix_a.elements[2][3] = 0;
+	matrix_a.elements[3][0] = 0; matrix_a.elements[3][1] = 0; matrix_a.elements[3][2] = 0; matrix_a.elements[3][3] = 1;
+
+	matrix_b.elements[0][0] = 5; matrix_b.elements[0][1] = 6; matrix_b.elements[0][2] = 0; matrix_b.elements[0][3] = 0;
+	matrix_b.elements[1][0] = 7; matrix_b.elements[1][1] = 8; matrix_b.elements[1][2] = 0; matrix_b.elements[1][3] = 0;
+	matrix_b.elements[2][0] = 0; matrix_b.elements[2][1] = 0; matrix_b.elements[2][2] = 1; matrix_b.elements[2][3] = 0;
+	matrix_b.elements[3][0] = 0; matrix_b.elements[3][1] = 0; matrix_b.elements[3][2] = 0; matrix_b.elements[3][3] = 1;
+
+	struct wlf_matrix4x4 product = wlf_matrix4x4_multiply(&matrix_a, &matrix_b);
+	struct wlf_matrix4x4 expected_product = wlf_matrix4x4_create_zero();
+	expected_product.elements[0][0] = 19; expected_product.elements[0][1] = 22; expected_product.elements[0][2] = 0; expected_product.elements[0][3] = 0;
+	expected_product.elements[1][0] = 43; expected_product.elements[1][1] = 50; expected_product.elements[1][2] = 0; expected_product.elements[1][3] = 0;
+	expected_product.elements[2][0] = 0; expected_product.elements[2][1] = 0; expected_product.elements[2][2] = 1; expected_product.elements[2][3] = 0;
+	expected_product.elements[3][0] = 0; expected_product.elements[3][1] = 0; expected_product.elements[3][2] = 0; expected_product.elements[3][3] = 1;
+
+	if (assert_matrix_equal(&product, &expected_product, EPSILON)) {
+		printf("✓ Matrix multiplication test passed\n");
+		passed_tests++;
+	} else {
+		printf("✗ Matrix multiplication test failed\n");
+	}
+}
+
+static void test_matrix4x4_transpose(void) {
+	print_test_header("Matrix4x4 Transpose Tests");
+
+	// Test identity matrix transpose
+	test_count++;
+	struct wlf_matrix4x4 identity = wlf_matrix4x4_identity();
+	struct wlf_matrix4x4 transposed_identity = wlf_matrix4x4_transpose(&identity);
+
+	if (assert_matrix_equal(&transposed_identity, &identity, EPSILON)) {
+		printf("✓ Identity matrix transpose test passed\n");
+		passed_tests++;
+	} else {
+		printf("✗ Identity matrix transpose test failed\n");
+	}
+
+	// Test general matrix transpose
+	test_count++;
+	struct wlf_matrix4x4 matrix = wlf_matrix4x4_create_zero();
+	for (int i = 0; i < 4; i++) {
+		for (int j = 0; j < 4; j++) {
+			matrix.elements[i][j] = i * 4 + j + 1;
+		}
+	}
+
+	struct wlf_matrix4x4 transposed = wlf_matrix4x4_transpose(&matrix);
+	struct wlf_matrix4x4 expected_transposed = wlf_matrix4x4_create_zero();
+	for (int i = 0; i < 4; i++) {
+		for (int j = 0; j < 4; j++) {
+			expected_transposed.elements[j][i] = matrix.elements[i][j];
+		}
+	}
+
+	if (assert_matrix_equal(&transposed, &expected_transposed, EPSILON)) {
+		printf("✓ Matrix transpose test passed\n");
+		passed_tests++;
+	} else {
+		printf("✗ Matrix transpose test failed\n");
+	}
+
+	// Test double transpose property (A^T)^T = A
+	test_count++;
+	struct wlf_matrix4x4 double_transposed = wlf_matrix4x4_transpose(&transposed);
+
+	if (assert_matrix_equal(&double_transposed, &matrix, EPSILON)) {
+		printf("✓ Double transpose property test passed\n");
+		passed_tests++;
+	} else {
+		printf("✗ Double transpose property test failed\n");
+	}
+}
+
+static void test_matrix4x4_determinant(void) {
+	print_test_header("Matrix4x4 Determinant Tests");
+
+	// Test identity matrix determinant
+	test_count++;
+	struct wlf_matrix4x4 identity = wlf_matrix4x4_identity();
+	double det_identity = wlf_matrix4x4_determinant(&identity);
+
+	if (assert_double_equal(det_identity, 1.0, EPSILON)) {
+		printf("✓ Identity matrix determinant test passed\n");
+		passed_tests++;
+	} else {
+		printf("✗ Identity matrix determinant test failed: expected 1.0, got %f\n", det_identity);
+	}
+
+	// Test diagonal matrix determinant
+	test_count++;
+	struct wlf_matrix4x4 diagonal = wlf_matrix4x4_create_zero();
+	diagonal.elements[0][0] = 2; diagonal.elements[1][1] = 3;
+	diagonal.elements[2][2] = 4; diagonal.elements[3][3] = 5;
+
+	double det_diagonal = wlf_matrix4x4_determinant(&diagonal);
+	double expected_det = 2 * 3 * 4 * 5; // 120
+
+	if (assert_double_equal(det_diagonal, expected_det, EPSILON)) {
+		printf("✓ Diagonal matrix determinant test passed\n");
+		passed_tests++;
+	} else {
+		printf("✗ Diagonal matrix determinant test failed: expected %f, got %f\n", expected_det, det_diagonal);
+	}
+
+	// Test zero determinant (singular matrix)
+	test_count++;
+	struct wlf_matrix4x4 singular = wlf_matrix4x4_create_zero();
+	singular.elements[0][0] = 1; singular.elements[0][1] = 2; singular.elements[0][2] = 3; singular.elements[0][3] = 4;
+	singular.elements[1][0] = 2; singular.elements[1][1] = 4; singular.elements[1][2] = 6; singular.elements[1][3] = 8;
+	singular.elements[2][0] = 3; singular.elements[2][1] = 6; singular.elements[2][2] = 9; singular.elements[2][3] = 12;
+	singular.elements[3][0] = 4; singular.elements[3][1] = 8; singular.elements[3][2] = 12; singular.elements[3][3] = 16;
+
+	double det_singular = wlf_matrix4x4_determinant(&singular);
+
+	if (assert_double_equal(det_singular, 0.0, EPSILON)) {
+		printf("✓ Singular matrix determinant test passed\n");
+		passed_tests++;
+	} else {
+		printf("✗ Singular matrix determinant test failed: expected 0.0, got %f\n", det_singular);
+	}
+}
+
+static void test_matrix4x4_inverse(void) {
+	print_test_header("Matrix4x4 Inverse Tests");
+
+	// Test identity matrix inverse
+	test_count++;
+	struct wlf_matrix4x4 identity = wlf_matrix4x4_identity();
+	struct wlf_matrix4x4 inv_identity = wlf_matrix4x4_inverse(&identity);
+
+	if (assert_matrix_equal(&inv_identity, &identity, EPSILON)) {
+		printf("✓ Identity matrix inverse test passed\n");
+		passed_tests++;
+	} else {
+		printf("✗ Identity matrix inverse test failed\n");
+	}
+
+	// Test diagonal matrix inverse
+	test_count++;
+	struct wlf_matrix4x4 diagonal = wlf_matrix4x4_create_zero();
+	diagonal.elements[0][0] = 2; diagonal.elements[1][1] = 4;
+	diagonal.elements[2][2] = 8; diagonal.elements[3][3] = 16;
+
+	struct wlf_matrix4x4 inv_diagonal = wlf_matrix4x4_inverse(&diagonal);
+	struct wlf_matrix4x4 expected_inv_diagonal = wlf_matrix4x4_create_zero();
+	expected_inv_diagonal.elements[0][0] = 0.5; expected_inv_diagonal.elements[1][1] = 0.25;
+	expected_inv_diagonal.elements[2][2] = 0.125; expected_inv_diagonal.elements[3][3] = 0.0625;
+
+	if (assert_matrix_equal(&inv_diagonal, &expected_inv_diagonal, EPSILON)) {
+		printf("✓ Diagonal matrix inverse test passed\n");
+		passed_tests++;
+	} else {
+		printf("✗ Diagonal matrix inverse test failed\n");
+	}
+
+	// Test A * A^-1 = I
+	test_count++;
+	struct wlf_matrix4x4 product = wlf_matrix4x4_multiply(&diagonal, &inv_diagonal);
+
+	if (assert_matrix_equal(&product, &identity, EPSILON)) {
+		printf("✓ Matrix inverse property test passed\n");
+		passed_tests++;
+	} else {
+		printf("✗ Matrix inverse property test failed\n");
+	}
+
+	// Test singular matrix inverse (should return zero matrix)
+	test_count++;
+	struct wlf_matrix4x4 singular = wlf_matrix4x4_create_zero();
+	singular.elements[0][0] = 1; singular.elements[0][1] = 2; singular.elements[0][2] = 3; singular.elements[0][3] = 4;
+	singular.elements[1][0] = 2; singular.elements[1][1] = 4; singular.elements[1][2] = 6; singular.elements[1][3] = 8;
+	singular.elements[2][0] = 3; singular.elements[2][1] = 6; singular.elements[2][2] = 9; singular.elements[2][3] = 12;
+	singular.elements[3][0] = 4; singular.elements[3][1] = 8; singular.elements[3][2] = 12; singular.elements[3][3] = 16;
+
+	struct wlf_matrix4x4 inv_singular = wlf_matrix4x4_inverse(&singular);
+	struct wlf_matrix4x4 zero_matrix = wlf_matrix4x4_create_zero();
+
+	if (assert_matrix_equal(&inv_singular, &zero_matrix, EPSILON)) {
+		printf("✓ Singular matrix inverse test passed\n");
+		passed_tests++;
+	} else {
+		printf("✗ Singular matrix inverse test failed\n");
+	}
+}
+
+static void test_matrix4x4_equality(void) {
+	print_test_header("Matrix4x4 Equality Tests");
+
+	// Test exact equality
+	test_count++;
+	struct wlf_matrix4x4 matrix1 = wlf_matrix4x4_identity();
+	struct wlf_matrix4x4 matrix2 = wlf_matrix4x4_identity();
+
+	if (wlf_matrix4x4_equal(&matrix1, &matrix2)) {
+		printf("✓ Exact equality test passed\n");
+		passed_tests++;
+	} else {
+		printf("✗ Exact equality test failed\n");
+	}
+
+	// Test inequality
+	test_count++;
+	struct wlf_matrix4x4 matrix3 = wlf_matrix4x4_create_zero();
+	matrix3.elements[0][0] = 1.0001;
+
+	if (!wlf_matrix4x4_equal(&matrix1, &matrix3)) {
+		printf("✓ Inequality test passed\n");
+		passed_tests++;
+	} else {
+		printf("✗ Inequality test failed\n");
+	}
+
+	// Test nearly equal
+	test_count++;
+	struct wlf_matrix4x4 matrix4 = wlf_matrix4x4_identity();
+	matrix4.elements[0][0] = 1.0 + EPSILON/2;
+
+	if (wlf_matrix4x4_nearly_equal(&matrix1, &matrix4, EPSILON)) {
+		printf("✓ Nearly equal test passed\n");
+		passed_tests++;
+	} else {
+		printf("✗ Nearly equal test failed\n");
+	}
+
+	// Test not nearly equal
+	test_count++;
+	struct wlf_matrix4x4 matrix5 = wlf_matrix4x4_identity();
+	matrix5.elements[0][0] = 1.0 + EPSILON * 2;
+
+	if (!wlf_matrix4x4_nearly_equal(&matrix1, &matrix5, EPSILON)) {
+		printf("✓ Not nearly equal test passed\n");
+		passed_tests++;
+	} else {
+		printf("✗ Not nearly equal test failed\n");
+	}
+}
+
+static void test_matrix4x4_edge_cases(void) {
+	print_test_header("Matrix4x4 Edge Cases Tests");
+
+	// Test zero matrix operations
+	test_count++;
+	struct wlf_matrix4x4 zero_matrix = wlf_matrix4x4_create_zero();
+	struct wlf_matrix4x4 identity = wlf_matrix4x4_identity();
+
+	struct wlf_matrix4x4 zero_sum = wlf_matrix4x4_add(&zero_matrix, &identity);
+	struct wlf_matrix4x4 zero_diff = wlf_matrix4x4_subtract(&identity, &identity);
+	struct wlf_matrix4x4 zero_product = wlf_matrix4x4_multiply(&zero_matrix, &identity);
+
+	if (assert_matrix_equal(&zero_sum, &identity, EPSILON) &&
+		assert_matrix_equal(&zero_diff, &zero_matrix, EPSILON) &&
+		assert_matrix_equal(&zero_product, &zero_matrix, EPSILON)) {
+		printf("✓ Zero matrix operations test passed\n");
+		passed_tests++;
+	} else {
+		printf("✗ Zero matrix operations test failed\n");
+	}
+
+	// Test scalar zero multiplication
+	test_count++;
+	struct wlf_matrix4x4 scaled_zero = wlf_matrix4x4_multiply_scalar(&identity, 0.0);
+
+	if (assert_matrix_equal(&scaled_zero, &zero_matrix, EPSILON)) {
+		printf("✓ Scalar zero multiplication test passed\n");
+		passed_tests++;
+	} else {
+		printf("✗ Scalar zero multiplication test failed\n");
+	}
+
+	// Test negative scalar multiplication
+	test_count++;
+	struct wlf_matrix4x4 scaled_negative = wlf_matrix4x4_multiply_scalar(&identity, -1.0);
+	struct wlf_matrix4x4 expected_negative = wlf_matrix4x4_create_zero();
+	expected_negative.elements[0][0] = -1; expected_negative.elements[1][1] = -1;
+	expected_negative.elements[2][2] = -1; expected_negative.elements[3][3] = -1;
+
+	if (assert_matrix_equal(&scaled_negative, &expected_negative, EPSILON)) {
+		printf("✓ Negative scalar multiplication test passed\n");
+		passed_tests++;
+	} else {
+		printf("✗ Negative scalar multiplication test failed\n");
+	}
+}
+
+static void test_matrix4x4_mathematical_properties(void) {
+	print_test_header("Matrix4x4 Mathematical Properties Tests");
+
+	// Create test matrices
+	struct wlf_matrix4x4 matrix_a = wlf_matrix4x4_create_zero();
+	struct wlf_matrix4x4 matrix_b = wlf_matrix4x4_create_zero();
+	struct wlf_matrix4x4 matrix_c = wlf_matrix4x4_create_zero();
+
+	// Initialize matrices with different values
+	for (int i = 0; i < 4; i++) {
+		for (int j = 0; j < 4; j++) {
+			matrix_a.elements[i][j] = i + j + 1;
+			matrix_b.elements[i][j] = (i + 1) * (j + 1);
+			matrix_c.elements[i][j] = (i - j) + 3;
+		}
+	}
+
+	// Test commutativity of addition: A + B = B + A
+	test_count++;
+	struct wlf_matrix4x4 sum_ab = wlf_matrix4x4_add(&matrix_a, &matrix_b);
+	struct wlf_matrix4x4 sum_ba = wlf_matrix4x4_add(&matrix_b, &matrix_a);
+
+	if (assert_matrix_equal(&sum_ab, &sum_ba, EPSILON)) {
+		printf("✓ Addition commutativity test passed\n");
+		passed_tests++;
+	} else {
+		printf("✗ Addition commutativity test failed\n");
+	}
+
+	// Test associativity of addition: (A + B) + C = A + (B + C)
+	test_count++;
+	struct wlf_matrix4x4 sum_ab_c = wlf_matrix4x4_add(&sum_ab, &matrix_c);
+	struct wlf_matrix4x4 sum_bc = wlf_matrix4x4_add(&matrix_b, &matrix_c);
+	struct wlf_matrix4x4 sum_a_bc = wlf_matrix4x4_add(&matrix_a, &sum_bc);
+
+	if (assert_matrix_equal(&sum_ab_c, &sum_a_bc, EPSILON)) {
+		printf("✓ Addition associativity test passed\n");
+		passed_tests++;
+	} else {
+		printf("✗ Addition associativity test failed\n");
+	}
+
+	// Test distributivity of scalar multiplication: k(A + B) = kA + kB
+	test_count++;
+	double scalar = 2.5;
+	struct wlf_matrix4x4 scaled_sum = wlf_matrix4x4_multiply_scalar(&sum_ab, scalar);
+	struct wlf_matrix4x4 scaled_a = wlf_matrix4x4_multiply_scalar(&matrix_a, scalar);
+	struct wlf_matrix4x4 scaled_b = wlf_matrix4x4_multiply_scalar(&matrix_b, scalar);
+	struct wlf_matrix4x4 sum_scaled = wlf_matrix4x4_add(&scaled_a, &scaled_b);
+
+	if (assert_matrix_equal(&scaled_sum, &sum_scaled, EPSILON)) {
+		printf("✓ Scalar multiplication distributivity test passed\n");
+		passed_tests++;
+	} else {
+		printf("✗ Scalar multiplication distributivity test failed\n");
+	}
+
+	// Test transpose property: (A + B)^T = A^T + B^T
+	test_count++;
+	struct wlf_matrix4x4 transpose_sum = wlf_matrix4x4_transpose(&sum_ab);
+	struct wlf_matrix4x4 transpose_a = wlf_matrix4x4_transpose(&matrix_a);
+	struct wlf_matrix4x4 transpose_b = wlf_matrix4x4_transpose(&matrix_b);
+	struct wlf_matrix4x4 sum_transposes = wlf_matrix4x4_add(&transpose_a, &transpose_b);
+
+	if (assert_matrix_equal(&transpose_sum, &sum_transposes, EPSILON)) {
+		printf("✓ Transpose addition property test passed\n");
+		passed_tests++;
+	} else {
+		printf("✗ Transpose addition property test failed\n");
+	}
+}
+
+static void test_matrix4x4_string_representation(void) {
+	print_test_header("Matrix4x4 String Representation Tests");
+
+	// Test string representation
+	test_count++;
+	struct wlf_matrix4x4 matrix = wlf_matrix4x4_identity();
+	char* str_repr = wlf_matrix4x4_to_str(&matrix);
+
+	bool string_valid = (str_repr != NULL && strlen(str_repr) > 0);
+
+	if (string_valid) {
+		printf("✓ String representation test passed\n");
+		printf("  Matrix string: %s\n", str_repr);
+		passed_tests++;
+	} else {
+		printf("✗ String representation test failed\n");
+	}
+
+	if (str_repr) {
+		free(str_repr);
+	}
+}
+
+int main(void) {
+	printf("Starting comprehensive wlf_matrix4x4 test suite...\n");
+
+	test_matrix4x4_creation();
+	test_matrix4x4_basic_operations();
+	test_matrix4x4_arithmetic();
+	test_matrix4x4_matrix_multiplication();
+	test_matrix4x4_transpose();
+	test_matrix4x4_determinant();
+	test_matrix4x4_inverse();
+	test_matrix4x4_equality();
+	test_matrix4x4_mathematical_properties();
+	test_matrix4x4_edge_cases();
+	test_matrix4x4_string_representation();
+
+	print_test_summary();
+
+	return (passed_tests == test_count) ? 0 : 1;
+}

--- a/examples/math/wlf_point_test.c
+++ b/examples/math/wlf_point_test.c
@@ -1,0 +1,230 @@
+#include "wlf/math/wlf_point.h"
+#include "wlf/utils/wlf_log.h"
+
+#include <stdint.h>
+#include <stdlib.h>
+#include <stdio.h>
+
+int main(int argc, char *argv[]) {
+	wlf_log_init(WLF_DEBUG, NULL);
+
+	wlf_log(WLF_INFO, "=== WLF Point Test Suite ===");
+
+	// Test point creation
+	wlf_log(WLF_INFO, "\n--- Testing Point Creation ---");
+	struct wlf_point p1 = (struct wlf_point){.x = 3, .y = 4};
+	struct wlf_point p2 = (struct wlf_point){.x = -2, .y = 7};
+	struct wlf_point zero_point = (struct wlf_point){.x = 0, .y = 0};
+
+	char *p1_str = wlf_point_to_str(&p1);
+	char *p2_str = wlf_point_to_str(&p2);
+	char *zero_str = wlf_point_to_str(&zero_point);
+
+	wlf_log(WLF_INFO, "p1: %s", p1_str);
+	wlf_log(WLF_INFO, "p2: %s", p2_str);
+	wlf_log(WLF_INFO, "zero: %s", zero_str);
+
+	free(p1_str);
+	free(p2_str);
+	free(zero_str);
+
+	// Test constants
+	wlf_log(WLF_INFO, "\n--- Testing Constants ---");
+	char *zero_const_str = wlf_point_to_str(&WLF_POINT_ZERO);
+	char *unit_str = wlf_point_to_str(&WLF_POINT_UNIT);
+	char *unit_x_str = wlf_point_to_str(&WLF_POINT_UNIT_X);
+	char *unit_y_str = wlf_point_to_str(&WLF_POINT_UNIT_Y);
+
+	wlf_log(WLF_INFO, "WLF_POINT_ZERO: %s", zero_const_str);
+	wlf_log(WLF_INFO, "WLF_POINT_UNIT: %s", unit_str);
+	wlf_log(WLF_INFO, "WLF_POINT_UNIT_X: %s", unit_x_str);
+	wlf_log(WLF_INFO, "WLF_POINT_UNIT_Y: %s", unit_y_str);
+
+	free(zero_const_str);
+	free(unit_str);
+	free(unit_x_str);
+	free(unit_y_str);
+
+	// Test equality
+	wlf_log(WLF_INFO, "\n--- Testing Equality ---");
+	struct wlf_point p1_copy = (struct wlf_point){.x = 3, .y = 4};
+	bool equal = wlf_point_equal(&p1, &p1_copy);
+	bool not_equal = wlf_point_equal(&p1, &p2);
+	wlf_log(WLF_INFO, "p1 == p1_copy: %s", equal ? "true" : "false");
+	wlf_log(WLF_INFO, "p1 == p2: %s", not_equal ? "true" : "false");
+
+	// Test zero check
+	wlf_log(WLF_INFO, "\n--- Testing Zero Check ---");
+	bool is_zero = wlf_point_is_zero(&zero_point);
+	bool is_not_zero = wlf_point_is_zero(&p1);
+	wlf_log(WLF_INFO, "zero_point is zero: %s", is_zero ? "true" : "false");
+	wlf_log(WLF_INFO, "p1 is zero: %s", is_not_zero ? "true" : "false");
+
+	// Test arithmetic operations
+	wlf_log(WLF_INFO, "\n--- Testing Arithmetic Operations ---");
+	struct wlf_point sum = wlf_point_add(&p1, &p2);
+	struct wlf_point diff = wlf_point_subtract(&p1, &p2);
+	struct wlf_point scaled = wlf_point_multiply(&p1, 3);
+
+	char *sum_str = wlf_point_to_str(&sum);
+	char *diff_str = wlf_point_to_str(&diff);
+	char *scaled_str = wlf_point_to_str(&scaled);
+
+	wlf_log(WLF_INFO, "p1 + p2 = %s", sum_str);
+	wlf_log(WLF_INFO, "p1 - p2 = %s", diff_str);
+	wlf_log(WLF_INFO, "p1 * 3 = %s", scaled_str);
+
+	free(sum_str);
+	free(diff_str);
+	free(scaled_str);
+
+	// Test distance calculations
+	wlf_log(WLF_INFO, "\n--- Testing Distance Calculations ---");
+	int manhattan_dist = wlf_point_manhattan_distance(&p1, &p2);
+	double euclidean_dist = wlf_point_euclidean_distance(&p1, &p2);
+
+	wlf_log(WLF_INFO, "Manhattan distance between p1 and p2: %d", manhattan_dist);
+	wlf_log(WLF_INFO, "Euclidean distance between p1 and p2: %.3f", euclidean_dist);
+
+	// Test with specific known values
+	wlf_log(WLF_INFO, "\n--- Testing Known Distance Values ---");
+	struct wlf_point origin = (struct wlf_point){.x = 0, .y = 0};
+	struct wlf_point point_3_4 = (struct wlf_point){.x = 3, .y = 4};
+
+	int manhattan_3_4 = wlf_point_manhattan_distance(&origin, &point_3_4);
+	double euclidean_3_4 = wlf_point_euclidean_distance(&origin, &point_3_4);
+
+	char *origin_str = wlf_point_to_str(&origin);
+	char *point_3_4_str = wlf_point_to_str(&point_3_4);
+
+	wlf_log(WLF_INFO, "From %s to %s:", origin_str, point_3_4_str);
+	wlf_log(WLF_INFO, "  Manhattan distance: %d (expected: 7)", manhattan_3_4);
+	wlf_log(WLF_INFO, "  Euclidean distance: %.3f (expected: 5.000)", euclidean_3_4);
+
+	free(origin_str);
+	free(point_3_4_str);
+
+	// Test edge cases
+	wlf_log(WLF_INFO, "\n--- Testing Edge Cases ---");
+
+	// Distance from point to itself
+	int self_manhattan = wlf_point_manhattan_distance(&p1, &p1);
+	double self_euclidean = wlf_point_euclidean_distance(&p1, &p1);
+	wlf_log(WLF_INFO, "Distance from point to itself: Manhattan=%d, Euclidean=%.3f",
+			self_manhattan, self_euclidean);
+
+	// Operations with negative numbers
+	struct wlf_point neg1 = (struct wlf_point){.x = -5, .y = -3};
+	struct wlf_point neg2 = (struct wlf_point){.x = -2, .y = -7};
+	struct wlf_point neg_sum = wlf_point_add(&neg1, &neg2);
+
+	char *neg1_str = wlf_point_to_str(&neg1);
+	char *neg2_str = wlf_point_to_str(&neg2);
+	char *neg_sum_str = wlf_point_to_str(&neg_sum);
+
+	wlf_log(WLF_INFO, "Negative addition: %s + %s = %s", neg1_str, neg2_str, neg_sum_str);
+
+	free(neg1_str);
+	free(neg2_str);
+	free(neg_sum_str);
+
+	// Test scalar multiplication with negative numbers
+	struct wlf_point neg_scaled = wlf_point_multiply(&p1, -2);
+	char *neg_scaled_str = wlf_point_to_str(&neg_scaled);
+	wlf_log(WLF_INFO, "p1 * -2 = %s", neg_scaled_str);
+	free(neg_scaled_str);
+
+	// Test string parsing
+	wlf_log(WLF_INFO, "\n--- Testing String Parsing ---");
+
+	// Test valid string parsing
+	struct wlf_point parsed_point;
+	bool parse_success;
+
+	// Basic positive numbers
+	parse_success = wlf_point_from_str("(10, 20)", &parsed_point);
+	char *parsed_str = wlf_point_to_str(&parsed_point);
+	wlf_log(WLF_INFO, "Parse \"(10, 20)\": %s -> %s",
+			parse_success ? "SUCCESS" : "FAILED", parsed_str);
+	free(parsed_str);
+
+	// Negative numbers
+	parse_success = wlf_point_from_str("(-5, 15)", &parsed_point);
+	parsed_str = wlf_point_to_str(&parsed_point);
+	wlf_log(WLF_INFO, "Parse \"(-5, 15)\": %s -> %s",
+			parse_success ? "SUCCESS" : "FAILED", parsed_str);
+	free(parsed_str);
+
+	// With spaces
+	parse_success = wlf_point_from_str("( 100 , -200 )", &parsed_point);
+	parsed_str = wlf_point_to_str(&parsed_point);
+	wlf_log(WLF_INFO, "Parse \"( 100 , -200 )\": %s -> %s",
+			parse_success ? "SUCCESS" : "FAILED", parsed_str);
+	free(parsed_str);
+
+	// Zero values
+	parse_success = wlf_point_from_str("(0, 0)", &parsed_point);
+	parsed_str = wlf_point_to_str(&parsed_point);
+	wlf_log(WLF_INFO, "Parse \"(0, 0)\": %s -> %s",
+			parse_success ? "SUCCESS" : "FAILED", parsed_str);
+	free(parsed_str);
+
+	// Test invalid string parsing
+	wlf_log(WLF_INFO, "\n--- Testing Invalid String Parsing ---");
+
+	// Missing opening bracket
+	parse_success = wlf_point_from_str("10, 20)", &parsed_point);
+	wlf_log(WLF_INFO, "Parse \"10, 20)\": %s (expected: FAILED)",
+			parse_success ? "SUCCESS" : "FAILED");
+
+	// Missing closing bracket
+	parse_success = wlf_point_from_str("(10, 20", &parsed_point);
+	wlf_log(WLF_INFO, "Parse \"(10, 20\": %s (expected: FAILED)",
+			parse_success ? "SUCCESS" : "FAILED");
+
+	// Missing comma
+	parse_success = wlf_point_from_str("(10 20)", &parsed_point);
+	wlf_log(WLF_INFO, "Parse \"(10 20)\": %s (expected: FAILED)",
+			parse_success ? "SUCCESS" : "FAILED");
+
+	// Invalid characters
+	parse_success = wlf_point_from_str("(abc, def)", &parsed_point);
+	wlf_log(WLF_INFO, "Parse \"(abc, def)\": %s (expected: FAILED)",
+			parse_success ? "SUCCESS" : "FAILED");
+
+	// NULL string
+	parse_success = wlf_point_from_str(NULL, &parsed_point);
+	wlf_log(WLF_INFO, "Parse NULL string: %s (expected: FAILED)",
+			parse_success ? "SUCCESS" : "FAILED");
+
+	// NULL point
+	parse_success = wlf_point_from_str("(10, 20)", NULL);
+	wlf_log(WLF_INFO, "Parse to NULL point: %s (expected: FAILED)",
+			parse_success ? "SUCCESS" : "FAILED");
+
+	// Empty string
+	parse_success = wlf_point_from_str("", &parsed_point);
+	wlf_log(WLF_INFO, "Parse empty string: %s (expected: FAILED)",
+			parse_success ? "SUCCESS" : "FAILED");
+
+	// Test round-trip conversion
+	wlf_log(WLF_INFO, "\n--- Testing Round-trip Conversion ---");
+	struct wlf_point original = (struct wlf_point){.x = 42, .y = -73};
+	char *original_str = wlf_point_to_str(&original);
+	struct wlf_point round_trip;
+	bool round_trip_success = wlf_point_from_str(original_str, &round_trip);
+	bool points_equal = wlf_point_equal(&original, &round_trip);
+
+	char *round_trip_str = wlf_point_to_str(&round_trip);
+	wlf_log(WLF_INFO, "Original: %s", original_str);
+	wlf_log(WLF_INFO, "Round-trip: %s", round_trip_str);
+	wlf_log(WLF_INFO, "Parse success: %s", round_trip_success ? "true" : "false");
+	wlf_log(WLF_INFO, "Points equal: %s", points_equal ? "true" : "false");
+
+	free(original_str);
+	free(round_trip_str);
+
+	wlf_log(WLF_INFO, "\n=== Point Test Suite Complete ===");
+
+	return 0;
+}

--- a/examples/math/wlf_quaternion_test.c
+++ b/examples/math/wlf_quaternion_test.c
@@ -1,0 +1,454 @@
+/**
+ * @file        wlf_quaternion_test.c
+ * @brief       Comprehensive test suite for wlf_quaternion functionality.
+ * @details     This file provides complete testing coverage for all wlf_quaternion
+ *              operations including creation, arithmetic, normalization, conjugation,
+ *              inversion, string conversion, and mathematical properties.
+ * @author      Test Suite
+ * @date        2024-12-17
+ * @version     v1.0
+ */
+
+#include "wlf/math/wlf_quaternion.h"
+
+#include <stdio.h>
+#include <math.h>
+#include <stdlib.h>
+#include <string.h>
+
+#ifndef M_PI
+#define M_PI 3.14159265358979323846
+#endif
+
+// Test configuration
+static const double EPSILON = 1e-9;
+static int test_count = 0;
+static int passed_tests = 0;
+
+// Function prototypes
+static void print_test_header(const char* test_name);
+static void print_test_summary(void);
+static void test_quaternion_creation(void);
+static void test_quaternion_constants(void);
+static void test_quaternion_arithmetic(void);
+static void test_quaternion_conjugate(void);
+static void test_quaternion_norm_and_normalize(void);
+static void test_quaternion_inverse(void);
+static void test_quaternion_equality(void);
+static void test_quaternion_string_conversion(void);
+static void test_quaternion_mathematical_properties(void);
+static void test_quaternion_rotation_properties(void);
+static void test_quaternion_edge_cases(void);
+static void test_quaternion_unit_quaternions(void);
+
+// Helper macros for testing
+#define ASSERT_TRUE(condition, message) \
+	do { \
+		test_count++; \
+		if (condition) { \
+			passed_tests++; \
+			printf("✓ PASS: %s\n", message); \
+		} else { \
+			printf("✗ FAIL: %s\n", message); \
+		} \
+	} while(0)
+
+#define ASSERT_DOUBLE_EQ(a, b, message) \
+	ASSERT_TRUE(fabs((a) - (b)) < EPSILON, message)
+
+#define ASSERT_QUATERNION_EQ(a, b, message) \
+	ASSERT_TRUE(wlf_quaternion_nearly_equal(&(a), &(b), EPSILON), message)
+
+// Test helper functions
+static void print_test_header(const char* test_name) {
+	printf("\n=== %s ===\n", test_name);
+}
+
+static void print_test_summary(void) {
+	printf("\n" "=" "=" "=" "=" "=" "=" "=" "=" "=" "=" "=" "=" "=" "=" "=" "=" "=" "=" "=" "=" "=" "=" "=" "=" "=" "=" "=" "=" "=" "=" "=" "=" "=" "=" "=" "=" "=" "=" "=" "=" "\n");
+	printf("Test Summary: %d/%d tests passed (%.1f%%)\n",
+			passed_tests, test_count,
+			test_count > 0 ? (100.0 * passed_tests / test_count) : 0.0);
+	printf("=" "=" "=" "=" "=" "=" "=" "=" "=" "=" "=" "=" "=" "=" "=" "=" "=" "=" "=" "=" "=" "=" "=" "=" "=" "=" "=" "=" "=" "=" "=" "=" "=" "=" "=" "=" "=" "=" "=" "=" "\n");
+}
+
+// Test functions
+static void test_quaternion_creation(void) {
+	print_test_header("Quaternion Creation Tests");
+
+	// Test basic quaternion creation
+	struct wlf_quaternion q1 = wlf_quaternion_make(1.0, 2.0, 3.0, 4.0);
+	ASSERT_DOUBLE_EQ(q1.w, 1.0, "Quaternion w component should match input");
+	ASSERT_DOUBLE_EQ(q1.x, 2.0, "Quaternion x component should match input");
+	ASSERT_DOUBLE_EQ(q1.y, 3.0, "Quaternion y component should match input");
+	ASSERT_DOUBLE_EQ(q1.z, 4.0, "Quaternion z component should match input");
+
+	// Test zero quaternion creation
+	struct wlf_quaternion zero = wlf_quaternion_make(0.0, 0.0, 0.0, 0.0);
+	ASSERT_DOUBLE_EQ(zero.w, 0.0, "Zero quaternion w should be 0");
+	ASSERT_DOUBLE_EQ(zero.x, 0.0, "Zero quaternion x should be 0");
+	ASSERT_DOUBLE_EQ(zero.y, 0.0, "Zero quaternion y should be 0");
+	ASSERT_DOUBLE_EQ(zero.z, 0.0, "Zero quaternion z should be 0");
+
+	// Test unit quaternion creation
+	struct wlf_quaternion unit = wlf_quaternion_make(1.0, 0.0, 0.0, 0.0);
+	ASSERT_DOUBLE_EQ(unit.w, 1.0, "Unit quaternion w should be 1");
+	ASSERT_DOUBLE_EQ(unit.x, 0.0, "Unit quaternion x should be 0");
+	ASSERT_DOUBLE_EQ(unit.y, 0.0, "Unit quaternion y should be 0");
+	ASSERT_DOUBLE_EQ(unit.z, 0.0, "Unit quaternion z should be 0");
+}
+
+static void test_quaternion_constants(void) {
+	print_test_header("Quaternion Constants Tests");
+
+	// Test identity quaternion constant
+	ASSERT_DOUBLE_EQ(WLF_QUATERNION_IDENTITY.w, 1.0, "Identity quaternion w should be 1");
+	ASSERT_DOUBLE_EQ(WLF_QUATERNION_IDENTITY.x, 0.0, "Identity quaternion x should be 0");
+	ASSERT_DOUBLE_EQ(WLF_QUATERNION_IDENTITY.y, 0.0, "Identity quaternion y should be 0");
+	ASSERT_DOUBLE_EQ(WLF_QUATERNION_IDENTITY.z, 0.0, "Identity quaternion z should be 0");
+
+	// Test that identity has norm 1
+	double identity_norm = wlf_quaternion_norm(&WLF_QUATERNION_IDENTITY);
+	ASSERT_DOUBLE_EQ(identity_norm, 1.0, "Identity quaternion should have norm 1");
+}
+
+static void test_quaternion_arithmetic(void) {
+	print_test_header("Quaternion Arithmetic Tests");
+
+	struct wlf_quaternion q1 = wlf_quaternion_make(1.0, 2.0, 3.0, 4.0);
+	struct wlf_quaternion q2 = wlf_quaternion_make(0.5, 1.5, 2.5, 3.5);
+
+	// Test addition
+	struct wlf_quaternion sum = wlf_quaternion_add(&q1, &q2);
+	struct wlf_quaternion expected_sum = wlf_quaternion_make(1.5, 3.5, 5.5, 7.5);
+	ASSERT_QUATERNION_EQ(sum, expected_sum, "Quaternion addition should be component-wise");
+
+	// Test subtraction
+	struct wlf_quaternion diff = wlf_quaternion_subtract(&q1, &q2);
+	struct wlf_quaternion expected_diff = wlf_quaternion_make(0.5, 0.5, 0.5, 0.5);
+	ASSERT_QUATERNION_EQ(diff, expected_diff, "Quaternion subtraction should be component-wise");
+
+	// Test multiplication (Hamilton product)
+	struct wlf_quaternion prod = wlf_quaternion_multiply(&q1, &q2);
+	// Manual calculation: (1,2,3,4) * (0.5,1.5,2.5,3.5)
+	// w = 1*0.5 - 2*1.5 - 3*2.5 - 4*3.5 = 0.5 - 3 - 7.5 - 14 = -24
+	// x = 1*1.5 + 2*0.5 + 3*3.5 - 4*2.5 = 1.5 + 1 + 10.5 - 10 = 3
+	// y = 1*2.5 - 2*3.5 + 3*0.5 + 4*1.5 = 2.5 - 7 + 1.5 + 6 = 3
+	// z = 1*3.5 + 2*2.5 - 3*1.5 + 4*0.5 = 3.5 + 5 - 4.5 + 2 = 6
+	struct wlf_quaternion expected_prod = wlf_quaternion_make(-24.0, 3.0, 3.0, 6.0);
+	ASSERT_QUATERNION_EQ(prod, expected_prod, "Quaternion multiplication should follow Hamilton product rules");
+
+	// Test multiplication with identity
+	struct wlf_quaternion identity_prod = wlf_quaternion_multiply(&q1, &WLF_QUATERNION_IDENTITY);
+	ASSERT_QUATERNION_EQ(identity_prod, q1, "Multiplication with identity should return original quaternion");
+
+	struct wlf_quaternion identity_prod2 = wlf_quaternion_multiply(&WLF_QUATERNION_IDENTITY, &q1);
+	ASSERT_QUATERNION_EQ(identity_prod2, q1, "Identity multiplication should be commutative");
+}
+
+static void test_quaternion_conjugate(void) {
+	print_test_header("Quaternion Conjugate Tests");
+
+	struct wlf_quaternion q = wlf_quaternion_make(1.0, 2.0, 3.0, 4.0);
+	struct wlf_quaternion conjugate = wlf_quaternion_conjugate(&q);
+
+	// Conjugate should negate x, y, z components
+	struct wlf_quaternion expected_conj = wlf_quaternion_make(1.0, -2.0, -3.0, -4.0);
+	ASSERT_QUATERNION_EQ(conjugate, expected_conj, "Conjugate should negate vector components");
+
+	// Test double conjugate
+	struct wlf_quaternion double_conj = wlf_quaternion_conjugate(&conjugate);
+	ASSERT_QUATERNION_EQ(double_conj, q, "Double conjugate should return original quaternion");
+
+	// Test conjugate of identity
+	struct wlf_quaternion identity_conj = wlf_quaternion_conjugate(&WLF_QUATERNION_IDENTITY);
+	ASSERT_QUATERNION_EQ(identity_conj, WLF_QUATERNION_IDENTITY, "Conjugate of identity should be identity");
+
+	// Test conjugate property: conj(q1 * q2) = conj(q2) * conj(q1)
+	struct wlf_quaternion q1 = wlf_quaternion_make(1.0, 1.0, 0.0, 0.0);
+	struct wlf_quaternion q2 = wlf_quaternion_make(0.0, 0.0, 1.0, 1.0);
+	struct wlf_quaternion prod = wlf_quaternion_multiply(&q1, &q2);
+	struct wlf_quaternion conj_prod = wlf_quaternion_conjugate(&prod);
+
+	struct wlf_quaternion conj_q1 = wlf_quaternion_conjugate(&q1);
+	struct wlf_quaternion conj_q2 = wlf_quaternion_conjugate(&q2);
+	struct wlf_quaternion conj_q2_times_conj_q1 = wlf_quaternion_multiply(&conj_q2, &conj_q1);
+
+	ASSERT_QUATERNION_EQ(conj_prod, conj_q2_times_conj_q1, "Conjugate distribution property should hold");
+}
+
+static void test_quaternion_norm_and_normalize(void) {
+	print_test_header("Quaternion Norm and Normalize Tests");
+
+	// Test norm calculation
+	struct wlf_quaternion q = wlf_quaternion_make(1.0, 2.0, 3.0, 4.0);
+	double norm = wlf_quaternion_norm(&q);
+	double expected_norm = sqrt(1*1 + 2*2 + 3*3 + 4*4); // sqrt(30)
+	ASSERT_DOUBLE_EQ(norm, expected_norm, "Norm should be sqrt of sum of squares");
+
+	// Test normalization
+	struct wlf_quaternion normalized = wlf_quaternion_normalize(&q);
+	double normalized_norm = wlf_quaternion_norm(&normalized);
+	ASSERT_DOUBLE_EQ(normalized_norm, 1.0, "Normalized quaternion should have norm 1");
+
+	// Test normalization preserves direction
+	struct wlf_quaternion scaled_back = wlf_quaternion_make(
+		normalized.w * expected_norm,
+		normalized.x * expected_norm,
+		normalized.y * expected_norm,
+		normalized.z * expected_norm
+	);
+	ASSERT_QUATERNION_EQ(scaled_back, q, "Normalization should preserve direction");
+
+	// Test identity normalization
+	struct wlf_quaternion identity_normalized = wlf_quaternion_normalize(&WLF_QUATERNION_IDENTITY);
+	ASSERT_QUATERNION_EQ(identity_normalized, WLF_QUATERNION_IDENTITY, "Identity normalization should return identity");
+
+	// Test zero quaternion normalization
+	struct wlf_quaternion zero = wlf_quaternion_make(0.0, 0.0, 0.0, 0.0);
+	struct wlf_quaternion zero_normalized = wlf_quaternion_normalize(&zero);
+	ASSERT_QUATERNION_EQ(zero_normalized, WLF_QUATERNION_IDENTITY, "Zero quaternion normalization should return identity");
+}
+
+static void test_quaternion_inverse(void) {
+	print_test_header("Quaternion Inverse Tests");
+
+	// Test inverse of unit quaternion
+	struct wlf_quaternion temp_q = wlf_quaternion_make(1.0, 1.0, 1.0, 1.0);
+	struct wlf_quaternion unit_q = wlf_quaternion_normalize(&temp_q);
+	struct wlf_quaternion inverse = wlf_quaternion_inverse(&unit_q);
+
+	// For unit quaternions, inverse equals conjugate
+	struct wlf_quaternion conjugate = wlf_quaternion_conjugate(&unit_q);
+	ASSERT_QUATERNION_EQ(inverse, conjugate, "Inverse of unit quaternion should equal conjugate");
+
+	// Test q * q^(-1) = identity
+	struct wlf_quaternion prod_with_inverse = wlf_quaternion_multiply(&unit_q, &inverse);
+	ASSERT_QUATERNION_EQ(prod_with_inverse, WLF_QUATERNION_IDENTITY, "Quaternion times its inverse should equal identity");
+
+	// Test q^(-1) * q = identity
+	struct wlf_quaternion inverse_prod = wlf_quaternion_multiply(&inverse, &unit_q);
+	ASSERT_QUATERNION_EQ(inverse_prod, WLF_QUATERNION_IDENTITY, "Inverse times quaternion should equal identity");
+
+	// Test identity inverse
+	struct wlf_quaternion identity_inverse = wlf_quaternion_inverse(&WLF_QUATERNION_IDENTITY);
+	ASSERT_QUATERNION_EQ(identity_inverse, WLF_QUATERNION_IDENTITY, "Inverse of identity should be identity");
+
+	// Test non-unit quaternion inverse
+	struct wlf_quaternion q = wlf_quaternion_make(2.0, 1.0, 0.0, 0.0);
+	struct wlf_quaternion q_inverse = wlf_quaternion_inverse(&q);
+	struct wlf_quaternion q_times_inverse = wlf_quaternion_multiply(&q, &q_inverse);
+	ASSERT_QUATERNION_EQ(q_times_inverse, WLF_QUATERNION_IDENTITY, "Non-unit quaternion times its inverse should equal identity");
+}
+
+static void test_quaternion_equality(void) {
+	print_test_header("Quaternion Equality Tests");
+
+	// Test exact equality
+	struct wlf_quaternion q1 = wlf_quaternion_make(1.0, 2.0, 3.0, 4.0);
+	struct wlf_quaternion q2 = wlf_quaternion_make(1.0, 2.0, 3.0, 4.0);
+	ASSERT_TRUE(wlf_quaternion_equal(&q1, &q2), "Identical quaternions should be equal");
+
+	// Test inequality
+	struct wlf_quaternion q3 = wlf_quaternion_make(1.1, 2.0, 3.0, 4.0);
+	ASSERT_TRUE(!wlf_quaternion_equal(&q1, &q3), "Different quaternions should not be equal");
+
+	// Test nearly equal
+	struct wlf_quaternion q4 = wlf_quaternion_make(1.0 + 1e-10, 2.0, 3.0, 4.0);
+	ASSERT_TRUE(wlf_quaternion_nearly_equal(&q1, &q4, 1e-9), "Nearly identical quaternions should be nearly equal");
+	ASSERT_TRUE(!wlf_quaternion_nearly_equal(&q1, &q4, 1e-11), "Quaternions outside epsilon should not be nearly equal");
+
+	// Test self equality
+	ASSERT_TRUE(wlf_quaternion_equal(&q1, &q1), "Quaternion should equal itself");
+	ASSERT_TRUE(wlf_quaternion_nearly_equal(&q1, &q1, 1e-15), "Quaternion should be nearly equal to itself");
+}
+
+static void test_quaternion_string_conversion(void) {
+	print_test_header("Quaternion String Conversion Tests");
+
+	struct wlf_quaternion q = wlf_quaternion_make(1.0, 2.0, 3.0, 4.0);
+	char* q_str = wlf_quaternion_to_str(&q);
+
+	ASSERT_TRUE(q_str != NULL, "String conversion should not return NULL");
+	ASSERT_TRUE(strstr(q_str, "Quaternion") != NULL, "String should contain 'Quaternion'");
+	ASSERT_TRUE(strstr(q_str, "1.00") != NULL, "String should contain w component");
+	ASSERT_TRUE(strstr(q_str, "2.00") != NULL, "String should contain x component");
+	ASSERT_TRUE(strstr(q_str, "3.00") != NULL, "String should contain y component");
+	ASSERT_TRUE(strstr(q_str, "4.00") != NULL, "String should contain z component");
+
+	printf("Quaternion string: %s\n", q_str);
+	free(q_str);
+
+	// Test identity string conversion
+	char* identity_str = wlf_quaternion_to_str(&WLF_QUATERNION_IDENTITY);
+	ASSERT_TRUE(identity_str != NULL, "Identity string conversion should not return NULL");
+	printf("Identity quaternion string: %s\n", identity_str);
+	free(identity_str);
+}
+
+static void test_quaternion_mathematical_properties(void) {
+	print_test_header("Quaternion Mathematical Properties Tests");
+
+	struct wlf_quaternion q1 = wlf_quaternion_make(1.0, 1.0, 0.0, 0.0);
+	struct wlf_quaternion q2 = wlf_quaternion_make(0.0, 0.0, 1.0, 1.0);
+	struct wlf_quaternion q3 = wlf_quaternion_make(0.5, 0.5, 0.5, 0.5);
+
+	// Test associativity: (q1 * q2) * q3 = q1 * (q2 * q3)
+	struct wlf_quaternion temp_prod_12 = wlf_quaternion_multiply(&q1, &q2);
+	struct wlf_quaternion left_assoc = wlf_quaternion_multiply(&temp_prod_12, &q3);
+	struct wlf_quaternion temp_prod_23 = wlf_quaternion_multiply(&q2, &q3);
+	struct wlf_quaternion right_assoc = wlf_quaternion_multiply(&q1, &temp_prod_23);
+	ASSERT_QUATERNION_EQ(left_assoc, right_assoc, "Quaternion multiplication should be associative");
+
+	// Test distributivity of addition over multiplication: q1 * (q2 + q3) = q1*q2 + q1*q3
+	struct wlf_quaternion sum_23 = wlf_quaternion_add(&q2, &q3);
+	struct wlf_quaternion left_dist = wlf_quaternion_multiply(&q1, &sum_23);
+	struct wlf_quaternion prod_12 = wlf_quaternion_multiply(&q1, &q2);
+	struct wlf_quaternion prod_13 = wlf_quaternion_multiply(&q1, &q3);
+	struct wlf_quaternion right_dist = wlf_quaternion_add(&prod_12, &prod_13);
+	ASSERT_QUATERNION_EQ(left_dist, right_dist, "Multiplication should be distributive over addition");
+
+	// Test norm property: |q1 * q2| = |q1| * |q2|
+	struct wlf_quaternion prod_12_test = wlf_quaternion_multiply(&q1, &q2);
+	double norm_prod = wlf_quaternion_norm(&prod_12_test);
+	double prod_norms = wlf_quaternion_norm(&q1) * wlf_quaternion_norm(&q2);
+	ASSERT_DOUBLE_EQ(norm_prod, prod_norms, "Norm of product should equal product of norms");
+
+	// Test that quaternion multiplication is generally non-commutative
+	struct wlf_quaternion prod_21 = wlf_quaternion_multiply(&q2, &q1);
+	ASSERT_TRUE(!wlf_quaternion_nearly_equal(&prod_12_test, &prod_21, EPSILON),
+				"Quaternion multiplication should generally be non-commutative");
+}
+
+static void test_quaternion_rotation_properties(void) {
+	print_test_header("Quaternion Rotation Properties Tests");
+
+	// Test unit quaternions for rotation
+	// Rotation of 90 degrees around z-axis: q = (cos(45°), 0, 0, sin(45°))
+	double angle = M_PI / 4; // 45 degrees (half angle for quaternion)
+	struct wlf_quaternion rot_z = wlf_quaternion_make(cos(angle), 0.0, 0.0, sin(angle));
+
+	double norm = wlf_quaternion_norm(&rot_z);
+	ASSERT_DOUBLE_EQ(norm, 1.0, "Rotation quaternion should be unit quaternion");
+
+	// Test 180-degree rotation: q = (0, 0, 0, 1) for z-axis
+	struct wlf_quaternion rot_180_z = wlf_quaternion_make(0.0, 0.0, 0.0, 1.0);
+	double norm_180 = wlf_quaternion_norm(&rot_180_z);
+	ASSERT_DOUBLE_EQ(norm_180, 1.0, "180-degree rotation quaternion should be unit");
+
+	// Test that rotation by 360 degrees equals identity (up to sign)
+	// 360 degree rotation = q^4 for 90-degree rotation
+	struct wlf_quaternion rot_z_2 = wlf_quaternion_multiply(&rot_z, &rot_z);
+	struct wlf_quaternion rot_z_4 = wlf_quaternion_multiply(&rot_z_2, &rot_z_2);
+
+	// 360-degree rotation should be ±identity
+	struct wlf_quaternion neg_identity_rot = wlf_quaternion_make(-1, 0, 0, 0);
+	ASSERT_TRUE(wlf_quaternion_nearly_equal(&rot_z_4, &WLF_QUATERNION_IDENTITY, EPSILON) ||
+				wlf_quaternion_nearly_equal(&rot_z_4, &neg_identity_rot, EPSILON),
+				"360-degree rotation should equal ±identity");
+}
+
+static void test_quaternion_edge_cases(void) {
+	print_test_header("Quaternion Edge Cases Tests");
+
+	// Test very small quaternions
+	struct wlf_quaternion tiny = wlf_quaternion_make(1e-10, 1e-10, 1e-10, 1e-10);
+	double tiny_norm = wlf_quaternion_norm(&tiny);
+	ASSERT_TRUE(tiny_norm < 1e-9, "Tiny quaternion should have small norm");
+
+	struct wlf_quaternion tiny_normalized = wlf_quaternion_normalize(&tiny);
+	double tiny_norm_after = wlf_quaternion_norm(&tiny_normalized);
+	ASSERT_DOUBLE_EQ(tiny_norm_after, 1.0, "Normalized tiny quaternion should have unit norm");
+
+	// Test very large quaternions
+	struct wlf_quaternion large = wlf_quaternion_make(1e6, 1e6, 1e6, 1e6);
+	double large_norm = wlf_quaternion_norm(&large);
+	ASSERT_TRUE(large_norm > 1e6, "Large quaternion should have large norm");
+
+	struct wlf_quaternion large_normalized = wlf_quaternion_normalize(&large);
+	double large_norm_after = wlf_quaternion_norm(&large_normalized);
+	ASSERT_DOUBLE_EQ(large_norm_after, 1.0, "Normalized large quaternion should have unit norm");
+
+	// Test zero quaternion edge cases
+	struct wlf_quaternion zero = wlf_quaternion_make(0.0, 0.0, 0.0, 0.0);
+	double zero_norm = wlf_quaternion_norm(&zero);
+	ASSERT_DOUBLE_EQ(zero_norm, 0.0, "Zero quaternion should have zero norm");
+
+	struct wlf_quaternion zero_inverse = wlf_quaternion_inverse(&zero);
+	ASSERT_QUATERNION_EQ(zero_inverse, WLF_QUATERNION_IDENTITY, "Zero quaternion inverse should return identity");
+}
+
+static void test_quaternion_unit_quaternions(void) {
+	print_test_header("Unit Quaternion Tests");
+
+	// Test some common unit quaternions
+	struct wlf_quaternion unit_quaternions[] = {
+		{1.0, 0.0, 0.0, 0.0},  // Identity
+		{0.0, 1.0, 0.0, 0.0},  // i
+		{0.0, 0.0, 1.0, 0.0},  // j
+		{0.0, 0.0, 0.0, 1.0},  // k
+		{0.7071067812, 0.7071067812, 0.0, 0.0},  // Normalized (1,1,0,0)
+		{0.5, 0.5, 0.5, 0.5}   // Normalized (1,1,1,1)
+	};
+
+	for (int i = 0; i < 6; i++) {
+		double norm = wlf_quaternion_norm(&unit_quaternions[i]);
+		char msg[100];
+		snprintf(msg, sizeof(msg), "Unit quaternion %d should have norm 1", i);
+		ASSERT_DOUBLE_EQ(norm, 1.0, msg);
+
+		// Test that inverse equals conjugate for unit quaternions
+		struct wlf_quaternion inverse = wlf_quaternion_inverse(&unit_quaternions[i]);
+		struct wlf_quaternion conjugate = wlf_quaternion_conjugate(&unit_quaternions[i]);
+		snprintf(msg, sizeof(msg), "Unit quaternion %d inverse should equal conjugate", i);
+		ASSERT_QUATERNION_EQ(inverse, conjugate, msg);
+	}
+
+	// Test fundamental quaternion relations: i^2 = j^2 = k^2 = ijk = -1
+	struct wlf_quaternion i = {0.0, 1.0, 0.0, 0.0};
+	struct wlf_quaternion j = {0.0, 0.0, 1.0, 0.0};
+	struct wlf_quaternion k = {0.0, 0.0, 0.0, 1.0};
+	struct wlf_quaternion neg_identity = {-1.0, 0.0, 0.0, 0.0};
+
+	struct wlf_quaternion i_squared = wlf_quaternion_multiply(&i, &i);
+	ASSERT_QUATERNION_EQ(i_squared, neg_identity, "i^2 should equal -1");
+
+	struct wlf_quaternion j_squared = wlf_quaternion_multiply(&j, &j);
+	ASSERT_QUATERNION_EQ(j_squared, neg_identity, "j^2 should equal -1");
+
+	struct wlf_quaternion k_squared = wlf_quaternion_multiply(&k, &k);
+	ASSERT_QUATERNION_EQ(k_squared, neg_identity, "k^2 should equal -1");
+
+	// Test ijk = -1
+	struct wlf_quaternion ij = wlf_quaternion_multiply(&i, &j);
+	struct wlf_quaternion ijk = wlf_quaternion_multiply(&ij, &k);
+	ASSERT_QUATERNION_EQ(ijk, neg_identity, "ijk should equal -1");
+
+	// Test fundamental relations: ij = k, ji = -k, etc.
+	ASSERT_QUATERNION_EQ(ij, k, "ij should equal k");
+
+	struct wlf_quaternion ji = wlf_quaternion_multiply(&j, &i);
+	struct wlf_quaternion neg_k = {0.0, 0.0, 0.0, -1.0};
+	ASSERT_QUATERNION_EQ(ji, neg_k, "ji should equal -k");
+}
+
+int main(void) {
+	printf("Starting wlf_quaternion comprehensive test suite...\n");
+
+	test_quaternion_creation();
+	test_quaternion_constants();
+	test_quaternion_arithmetic();
+	test_quaternion_conjugate();
+	test_quaternion_norm_and_normalize();
+	test_quaternion_inverse();
+	test_quaternion_equality();
+	test_quaternion_string_conversion();
+	test_quaternion_mathematical_properties();
+	test_quaternion_rotation_properties();
+	test_quaternion_edge_cases();
+	test_quaternion_unit_quaternions();
+
+	print_test_summary();
+
+	return (passed_tests == test_count) ? 0 : 1;
+}

--- a/examples/math/wlf_ray2_test.c
+++ b/examples/math/wlf_ray2_test.c
@@ -1,0 +1,347 @@
+/**
+ * @file        wlf_ray2_test.c
+ * @brief       Comprehensive test suite for wlf_ray2 functionality.
+ * @details     This file provides complete testing coverage for all wlf_ray2
+ *              operations including creation, point calculation, equality
+ *              checks, string conversion, and geometric properties.
+ * @author      Test Suite
+ * @date        2025-06-22
+ * @version     v1.0
+ */
+
+#include "wlf/math/wlf_ray2.h"
+#include "wlf/math/wlf_vector2.h"
+
+#include <stdio.h>
+#include <math.h>
+#include <stdlib.h>
+#include <string.h>
+
+// Test configuration
+static const double EPSILON = 1e-9;
+static int test_count = 0;
+static int passed_tests = 0;
+
+// Function prototypes
+static void print_test_header(const char* test_name);
+static void print_test_summary(void);
+static void test_ray_creation(void);
+static void test_ray_unit_axes(void);
+static void test_ray_point_at_parameter(void);
+static void test_ray_point_at_parameter_complex(void);
+static void test_ray_equality(void);
+static void test_ray_nearly_equal(void);
+static void test_ray_string_conversion(void);
+static void test_ray_geometric_properties(void);
+static void test_ray_edge_cases(void);
+static void test_ray_normalization_considerations(void);
+
+// Helper macros for testing
+#define ASSERT_TRUE(condition, message) \
+	do { \
+		test_count++; \
+		if (condition) { \
+			passed_tests++; \
+			printf("✓ PASS: %s\n", message); \
+		} else { \
+			printf("✗ FAIL: %s\n", message); \
+		} \
+	} while(0)
+
+#define ASSERT_DOUBLE_EQ(a, b, message) \
+	do { \
+		test_count++; \
+		if (fabs((a) - (b)) < EPSILON) { \
+			passed_tests++; \
+			printf("✓ PASS: %s\n", message); \
+		} else { \
+			printf("✗ FAIL: %s (expected %.9f, got %.9f)\n", message, (double)(b), (double)(a)); \
+		} \
+	} while(0)
+
+#define ASSERT_VECTOR2_EQ(v1, v2, message) \
+	do { \
+		test_count++; \
+		if (fabs((v1).u - (v2).u) < EPSILON && \
+			fabs((v1).v - (v2).v) < EPSILON) { \
+			passed_tests++; \
+			printf("✓ PASS: %s\n", message); \
+		} else { \
+			printf("✗ FAIL: %s (expected (%.9f, %.9f), got (%.9f, %.9f))\n", \
+				message, (v2).u, (v2).v, (v1).u, (v1).v); \
+		} \
+	} while(0)
+
+static void print_test_header(const char* test_name) {
+	printf("\n=== %s ===\n", test_name);
+}
+
+static void print_test_summary(void) {
+	printf("\n" "=" "=" "=" "=" "=" "=" "=" "=" "=" "=" "=" "=" "=" "=" "=" "=" "=" "=" "=" "=" "=" "=" "=" "=" "=" "=" "=" "=" "=" "=" "=" "=" "=" "=" "=" "=" "=" "=" "=" "=" "\n");
+	printf("TEST SUMMARY\n");
+	printf("" "=" "=" "=" "=" "=" "=" "=" "=" "=" "=" "=" "=" "=" "=" "=" "=" "=" "=" "=" "=" "=" "=" "=" "=" "=" "=" "=" "=" "=" "=" "=" "=" "=" "=" "=" "=" "=" "=" "=" "=" "\n");
+	printf("Total tests: %d\n", test_count);
+	printf("Passed: %d\n", passed_tests);
+	printf("Failed: %d\n", test_count - passed_tests);
+	printf("Success rate: %.1f%%\n", test_count > 0 ? (100.0 * passed_tests / test_count) : 0.0);
+	printf("" "=" "=" "=" "=" "=" "=" "=" "=" "=" "=" "=" "=" "=" "=" "=" "=" "=" "=" "=" "=" "=" "=" "=" "=" "=" "=" "=" "=" "=" "=" "=" "=" "=" "=" "=" "=" "=" "=" "=" "=" "\n");
+}
+
+static void test_ray_creation(void) {
+	print_test_header("Ray Creation Tests");
+	
+	// Test basic ray creation
+	struct wlf_vector2 origin = {1.0, 2.0};
+	struct wlf_vector2 direction = {1.0, 0.0};
+	struct wlf_ray2 ray = wlf_ray2_make(origin, direction);
+	
+	ASSERT_VECTOR2_EQ(ray.origin, origin, "Ray origin correctly set");
+	ASSERT_VECTOR2_EQ(ray.direction, direction, "Ray direction correctly set");
+	
+	// Test zero ray constant
+	ASSERT_VECTOR2_EQ(WLF_RAY2_ZERO.origin, ((struct wlf_vector2){0.0, 0.0}), "Zero ray origin is (0,0)");
+	ASSERT_VECTOR2_EQ(WLF_RAY2_ZERO.direction, ((struct wlf_vector2){0.0, 0.0}), "Zero ray direction is (0,0)");
+}
+
+static void test_ray_unit_axes(void) {
+	print_test_header("Ray Unit Axes Tests");
+	
+	// Test rays along unit axes
+	struct wlf_vector2 origin = {0.0, 0.0};
+	
+	// U-axis ray (horizontal right)
+	struct wlf_ray2 u_ray = wlf_ray2_make(origin, (struct wlf_vector2){1.0, 0.0});
+	ASSERT_VECTOR2_EQ(u_ray.direction, ((struct wlf_vector2){1.0, 0.0}), "U-axis ray direction is (1,0)");
+	
+	// V-axis ray (vertical up)
+	struct wlf_ray2 v_ray = wlf_ray2_make(origin, (struct wlf_vector2){0.0, 1.0});
+	ASSERT_VECTOR2_EQ(v_ray.direction, ((struct wlf_vector2){0.0, 1.0}), "V-axis ray direction is (0,1)");
+	
+	// Negative axes
+	struct wlf_ray2 neg_u_ray = wlf_ray2_make(origin, (struct wlf_vector2){-1.0, 0.0});
+	ASSERT_VECTOR2_EQ(neg_u_ray.direction, ((struct wlf_vector2){-1.0, 0.0}), "Negative U-axis ray direction is (-1,0)");
+	
+	struct wlf_ray2 neg_v_ray = wlf_ray2_make(origin, (struct wlf_vector2){0.0, -1.0});
+	ASSERT_VECTOR2_EQ(neg_v_ray.direction, ((struct wlf_vector2){0.0, -1.0}), "Negative V-axis ray direction is (0,-1)");
+}
+
+static void test_ray_point_at_parameter(void) {
+	print_test_header("Ray Point at Parameter Tests");
+	
+	// Test basic parametric point calculation
+	struct wlf_vector2 origin = {1.0, 2.0};
+	struct wlf_vector2 direction = {3.0, 4.0};
+	struct wlf_ray2 ray = wlf_ray2_make(origin, direction);
+	
+	// At t=0, should return origin
+	struct wlf_vector2 point_at_0 = wlf_ray2_point_at_parameter(&ray, 0.0);
+	ASSERT_VECTOR2_EQ(point_at_0, origin, "Point at t=0 equals origin");
+	
+	// At t=1, should return origin + direction
+	struct wlf_vector2 point_at_1 = wlf_ray2_point_at_parameter(&ray, 1.0);
+	struct wlf_vector2 expected_at_1 = {4.0, 6.0}; // (1+3, 2+4)
+	ASSERT_VECTOR2_EQ(point_at_1, expected_at_1, "Point at t=1 equals origin + direction");
+	
+	// At t=0.5, should return origin + 0.5*direction
+	struct wlf_vector2 point_at_half = wlf_ray2_point_at_parameter(&ray, 0.5);
+	struct wlf_vector2 expected_at_half = {2.5, 4.0}; // (1+1.5, 2+2)
+	ASSERT_VECTOR2_EQ(point_at_half, expected_at_half, "Point at t=0.5 equals origin + 0.5*direction");
+	
+	// Test negative parameter
+	struct wlf_vector2 point_at_neg = wlf_ray2_point_at_parameter(&ray, -1.0);
+	struct wlf_vector2 expected_at_neg = {-2.0, -2.0}; // (1-3, 2-4)
+	ASSERT_VECTOR2_EQ(point_at_neg, expected_at_neg, "Point at t=-1 moves backwards along ray");
+}
+
+static void test_ray_point_at_parameter_complex(void) {
+	print_test_header("Ray Point at Parameter Complex Tests");
+	
+	// Test with diagonal ray (45 degrees)
+	struct wlf_vector2 origin = {0.0, 0.0};
+	struct wlf_vector2 direction = {1.0, 1.0}; // Not normalized, but that's ok for testing
+	struct wlf_ray2 diagonal_ray = wlf_ray2_make(origin, direction);
+	
+	struct wlf_vector2 point = wlf_ray2_point_at_parameter(&diagonal_ray, 2.0);
+	struct wlf_vector2 expected = {2.0, 2.0};
+	ASSERT_VECTOR2_EQ(point, expected, "Diagonal ray point calculation correct");
+	
+	// Test with normalized direction vector
+	double sqrt2 = sqrt(2.0);
+	struct wlf_vector2 norm_direction = {1.0/sqrt2, 1.0/sqrt2}; // Normalized diagonal
+	struct wlf_ray2 norm_ray = wlf_ray2_make(origin, norm_direction);
+	
+	struct wlf_vector2 norm_point = wlf_ray2_point_at_parameter(&norm_ray, sqrt2);
+	struct wlf_vector2 norm_expected = {1.0, 1.0};
+	ASSERT_VECTOR2_EQ(norm_point, norm_expected, "Normalized diagonal ray point calculation correct");
+}
+
+static void test_ray_equality(void) {
+	print_test_header("Ray Equality Tests");
+	
+	struct wlf_vector2 origin1 = {1.0, 2.0};
+	struct wlf_vector2 direction1 = {3.0, 4.0};
+	struct wlf_ray2 ray1 = wlf_ray2_make(origin1, direction1);
+	
+	struct wlf_vector2 origin2 = {1.0, 2.0};
+	struct wlf_vector2 direction2 = {3.0, 4.0};
+	struct wlf_ray2 ray2 = wlf_ray2_make(origin2, direction2);
+	
+	struct wlf_vector2 origin3 = {1.0, 2.0};
+	struct wlf_vector2 direction3 = {3.0, 5.0}; // Different direction
+	struct wlf_ray2 ray3 = wlf_ray2_make(origin3, direction3);
+	
+	struct wlf_vector2 origin4 = {2.0, 2.0}; // Different origin
+	struct wlf_vector2 direction4 = {3.0, 4.0};
+	struct wlf_ray2 ray4 = wlf_ray2_make(origin4, direction4);
+	
+	ASSERT_TRUE(wlf_ray2_equal(&ray1, &ray2), "Identical rays are equal");
+	ASSERT_TRUE(!wlf_ray2_equal(&ray1, &ray3), "Rays with different directions are not equal");
+	ASSERT_TRUE(!wlf_ray2_equal(&ray1, &ray4), "Rays with different origins are not equal");
+	ASSERT_TRUE(wlf_ray2_equal(&ray1, &ray1), "Ray is equal to itself");
+}
+
+static void test_ray_nearly_equal(void) {
+	print_test_header("Ray Nearly Equal Tests");
+	
+	struct wlf_vector2 origin1 = {1.0, 2.0};
+	struct wlf_vector2 direction1 = {3.0, 4.0};
+	struct wlf_ray2 ray1 = wlf_ray2_make(origin1, direction1);
+	
+	// Slightly different ray within epsilon
+	struct wlf_vector2 origin2 = {1.0000000001, 2.0000000001};
+	struct wlf_vector2 direction2 = {3.0000000001, 4.0000000001};
+	struct wlf_ray2 ray2 = wlf_ray2_make(origin2, direction2);
+	
+	// Ray outside epsilon
+	struct wlf_vector2 origin3 = {1.001, 2.001};
+	struct wlf_vector2 direction3 = {3.001, 4.001};
+	struct wlf_ray2 ray3 = wlf_ray2_make(origin3, direction3);
+	
+	ASSERT_TRUE(wlf_ray2_nearly_equal(&ray1, &ray2, 1e-8), 
+		"Nearly identical rays are nearly equal with appropriate epsilon");
+	ASSERT_TRUE(!wlf_ray2_nearly_equal(&ray1, &ray3, 1e-8), 
+		"Different rays are not nearly equal with small epsilon");
+	ASSERT_TRUE(wlf_ray2_nearly_equal(&ray1, &ray3, 0.01), 
+		"Different rays are nearly equal with large epsilon");
+}
+
+static void test_ray_string_conversion(void) {
+	print_test_header("Ray String Conversion Tests");
+	
+	struct wlf_vector2 origin = {1.5, 2.5};
+	struct wlf_vector2 direction = {0.0, 1.0};
+	struct wlf_ray2 ray = wlf_ray2_make(origin, direction);
+	
+	char* ray_str = wlf_ray2_to_str(&ray);
+	ASSERT_TRUE(ray_str != NULL, "String conversion returns non-NULL");
+	
+	if (ray_str) {
+		ASSERT_TRUE(strstr(ray_str, "Origin") != NULL, "String contains 'Origin'");
+		ASSERT_TRUE(strstr(ray_str, "Direction") != NULL, "String contains 'Direction'");
+		printf("Ray string representation: %s\n", ray_str);
+		free(ray_str);
+	}
+	
+	// Test NULL ray
+	char* null_str = wlf_ray2_to_str(NULL);
+	ASSERT_TRUE(null_str != NULL, "NULL ray string conversion returns non-NULL");
+	if (null_str) {
+		ASSERT_TRUE(strcmp(null_str, "(NULL)") == 0, "NULL ray returns '(NULL)' string");
+		free(null_str);
+	}
+}
+
+static void test_ray_geometric_properties(void) {
+	print_test_header("Ray Geometric Properties Tests");
+	
+	// Test ray through specific points
+	struct wlf_vector2 origin = {0.0, 0.0};
+	struct wlf_vector2 direction = {1.0, 1.0}; // 45-degree angle
+	struct wlf_ray2 ray = wlf_ray2_make(origin, direction);
+	
+	// Points along the ray should maintain the relationship: point = origin + t * direction
+	for (int i = 0; i < 5; i++) {
+		double t = i * 0.5;
+		struct wlf_vector2 point = wlf_ray2_point_at_parameter(&ray, t);
+		
+		// For this specific ray, u should equal v at all points
+		ASSERT_DOUBLE_EQ(point.u, point.v, "Points on 45-degree ray have equal u and v components");
+		
+		// Distance from origin should be t * |direction|
+		double distance = sqrt(point.u * point.u + point.v * point.v);
+		double expected_distance = t * sqrt(2.0); // |direction| = sqrt(1^2 + 1^2) = sqrt(2)
+		ASSERT_DOUBLE_EQ(distance, expected_distance, "Distance from origin equals t * |direction|");
+	}
+}
+
+static void test_ray_edge_cases(void) {
+	print_test_header("Ray Edge Cases Tests");
+	
+	// Test zero direction vector (degenerate ray)
+	struct wlf_vector2 origin = {1.0, 2.0};
+	struct wlf_vector2 zero_direction = {0.0, 0.0};
+	struct wlf_ray2 degenerate_ray = wlf_ray2_make(origin, zero_direction);
+	
+	// All points along a degenerate ray should be the origin
+	struct wlf_vector2 point1 = wlf_ray2_point_at_parameter(&degenerate_ray, 0.0);
+	struct wlf_vector2 point2 = wlf_ray2_point_at_parameter(&degenerate_ray, 1.0);
+	struct wlf_vector2 point3 = wlf_ray2_point_at_parameter(&degenerate_ray, -5.0);
+	
+	ASSERT_VECTOR2_EQ(point1, origin, "Degenerate ray point at t=0 is origin");
+	ASSERT_VECTOR2_EQ(point2, origin, "Degenerate ray point at t=1 is origin");
+	ASSERT_VECTOR2_EQ(point3, origin, "Degenerate ray point at t=-5 is origin");
+	
+	// Test very small direction vector
+	struct wlf_vector2 tiny_direction = {1e-10, 1e-10};
+	struct wlf_ray2 tiny_ray = wlf_ray2_make(origin, tiny_direction);
+	
+	struct wlf_vector2 tiny_point = wlf_ray2_point_at_parameter(&tiny_ray, 1e10);
+	struct wlf_vector2 expected_tiny = {1.0 + 1.0, 2.0 + 1.0}; // origin + 1e10 * 1e-10
+	ASSERT_VECTOR2_EQ(tiny_point, expected_tiny, "Tiny direction vector with large parameter works");
+}
+
+static void test_ray_normalization_considerations(void) {
+	print_test_header("Ray Normalization Considerations Tests");
+	
+	// Test that the API works with both normalized and non-normalized directions
+	struct wlf_vector2 origin = {0.0, 0.0};
+	
+	// Non-normalized direction
+	struct wlf_vector2 direction_long = {3.0, 4.0}; // Length = 5
+	struct wlf_ray2 ray_long = wlf_ray2_make(origin, direction_long);
+	
+	// Normalized direction
+	struct wlf_vector2 direction_norm = {0.6, 0.8}; // Length = 1
+	struct wlf_ray2 ray_norm = wlf_ray2_make(origin, direction_norm);
+	
+	// At t=1, non-normalized ray goes 5 units, normalized ray goes 1 unit
+	struct wlf_vector2 point_long = wlf_ray2_point_at_parameter(&ray_long, 1.0);
+	struct wlf_vector2 point_norm = wlf_ray2_point_at_parameter(&ray_norm, 1.0);
+	
+	ASSERT_VECTOR2_EQ(point_long, direction_long, "Non-normalized ray at t=1 gives direction vector");
+	ASSERT_VECTOR2_EQ(point_norm, direction_norm, "Normalized ray at t=1 gives unit direction");
+	
+	// But at t=5, normalized ray should reach the same point as non-normalized at t=1
+	struct wlf_vector2 point_norm_scaled = wlf_ray2_point_at_parameter(&ray_norm, 5.0);
+	ASSERT_VECTOR2_EQ(point_norm_scaled, direction_long, "Normalized ray at t=5 equals non-normalized at t=1");
+}
+
+int main(void) {
+	printf("wlf_ray2 Test Suite\n");
+	printf("===================\n");
+	
+	test_ray_creation();
+	test_ray_unit_axes();
+	test_ray_point_at_parameter();
+	test_ray_point_at_parameter_complex();
+	test_ray_equality();
+	test_ray_nearly_equal();
+	test_ray_string_conversion();
+	test_ray_geometric_properties();
+	test_ray_edge_cases();
+	test_ray_normalization_considerations();
+	
+	print_test_summary();
+	
+	return (test_count == passed_tests) ? 0 : 1;
+}

--- a/examples/math/wlf_ray3_test.c
+++ b/examples/math/wlf_ray3_test.c
@@ -1,0 +1,333 @@
+/**
+ * @file        wlf_ray3_test.c
+ * @brief       Comprehensive test suite for wlf_ray3 functionality.
+ * @details     This file provides complete testing coverage for all wlf_ray3
+ *              operations including creation, point calculation, equality
+ *              checks, string conversion, and geometric properties.
+ * @author      Test Suite
+ * @date        2024-12-17
+ * @version     v1.0
+ */
+
+#include "wlf/math/wlf_ray3.h"
+#include "wlf/math/wlf_vector3.h"
+
+#include <stdio.h>
+#include <math.h>
+#include <stdlib.h>
+#include <string.h>
+
+// Test configuration
+static const double EPSILON = 1e-9;
+static int test_count = 0;
+static int passed_tests = 0;
+
+// Function prototypes
+static void print_test_header(const char* test_name);
+static void print_test_summary(void);
+static void test_ray_creation(void);
+static void test_ray_unit_axes(void);
+static void test_ray_point_at_parameter(void);
+static void test_ray_point_at_parameter_complex(void);
+static void test_ray_equality(void);
+static void test_ray_nearly_equal(void);
+static void test_ray_string_conversion(void);
+static void test_ray_geometric_properties(void);
+static void test_ray_edge_cases(void);
+static void test_ray_normalization_considerations(void);
+
+// Helper macros for testing
+#define ASSERT_TRUE(condition, message) \
+	do { \
+		test_count++; \
+		if (condition) { \
+			passed_tests++; \
+			printf("✓ PASS: %s\n", message); \
+		} else { \
+			printf("✗ FAIL: %s\n", message); \
+		} \
+	} while(0)
+
+#define ASSERT_DOUBLE_EQ(a, b, message) \
+	ASSERT_TRUE(fabs((a) - (b)) < EPSILON, message)
+
+#define ASSERT_VECTOR3_EQ(a, b, message) \
+	ASSERT_TRUE(wlf_vector3_nearly_equal(&(a), &(b), EPSILON), message)
+
+void print_test_header(const char* test_name) {
+	printf("\n=== %s ===\n", test_name);
+}
+
+void print_test_summary(void) {
+	printf("\n" "=" "=" "=" "=" "=" "=" "=" "=" "=" "=" "=" "=" "=" "=" "=" "=" "=" "=" "=" "=" "=" "=" "=" "=" "=" "=" "=" "=" "=" "=" "=" "=" "=" "=" "=" "=" "=" "=" "=" "=" "\n");
+	printf("Test Summary: %d/%d tests passed (%.1f%%)\n",
+			passed_tests, test_count,
+			test_count > 0 ? (100.0 * passed_tests / test_count) : 0.0);
+	printf("=" "=" "=" "=" "=" "=" "=" "=" "=" "=" "=" "=" "=" "=" "=" "=" "=" "=" "=" "=" "=" "=" "=" "=" "=" "=" "=" "=" "=" "=" "=" "=" "=" "=" "=" "=" "=" "=" "=" "=" "\n");
+}
+
+// Test functions
+static void test_ray_creation(void) {
+	print_test_header("Ray Creation Tests");
+
+	// Test basic ray creation
+	struct wlf_vector3 origin = wlf_vector3_make(1.0, 2.0, 3.0);
+	struct wlf_vector3 direction = wlf_vector3_make(0.0, 1.0, 0.0);
+	struct wlf_ray3 ray = wlf_ray3_make(origin, direction);
+
+	ASSERT_VECTOR3_EQ(ray.origin, origin, "Ray origin should match input");
+	ASSERT_VECTOR3_EQ(ray.direction, direction, "Ray direction should match input");
+
+	// Test zero ray creation
+	struct wlf_vector3 zero = WLF_VECTOR3_ZERO;
+	struct wlf_ray3 zero_ray = wlf_ray3_make(zero, zero);
+
+	ASSERT_VECTOR3_EQ(zero_ray.origin, zero, "Zero ray origin should be zero");
+	ASSERT_VECTOR3_EQ(zero_ray.direction, zero, "Zero ray direction should be zero");
+
+	// Test WLF_RAY_ZERO constant
+	ASSERT_VECTOR3_EQ(WLF_RAY_ZERO.origin, zero, "WLF_RAY_ZERO origin should be zero");
+	ASSERT_VECTOR3_EQ(WLF_RAY_ZERO.direction, zero, "WLF_RAY_ZERO direction should be zero");
+}
+
+void test_ray_unit_axes(void) {
+	print_test_header("Ray Unit Axes Tests");
+
+	// Test rays along primary axes
+	struct wlf_vector3 origin = WLF_VECTOR3_ZERO;
+
+	// X-axis ray
+	struct wlf_ray3 x_ray = wlf_ray3_make(origin, WLF_VECTOR3_UNIT_X);
+	ASSERT_VECTOR3_EQ(x_ray.direction, WLF_VECTOR3_UNIT_X, "X-axis ray direction");
+
+	// Y-axis ray
+	struct wlf_ray3 y_ray = wlf_ray3_make(origin, WLF_VECTOR3_UNIT_Y);
+	ASSERT_VECTOR3_EQ(y_ray.direction, WLF_VECTOR3_UNIT_Y, "Y-axis ray direction");
+
+	// Z-axis ray
+	struct wlf_ray3 z_ray = wlf_ray3_make(origin, WLF_VECTOR3_UNIT_Z);
+	ASSERT_VECTOR3_EQ(z_ray.direction, WLF_VECTOR3_UNIT_Z, "Z-axis ray direction");
+}
+
+void test_ray_point_at_parameter(void) {
+	print_test_header("Ray Point At Parameter Tests");
+
+	// Test ray from origin along x-axis
+	struct wlf_vector3 origin = WLF_VECTOR3_ZERO;
+	struct wlf_vector3 direction = WLF_VECTOR3_UNIT_X;
+	struct wlf_ray3 ray = wlf_ray3_make(origin, direction);
+
+	// Test various parameter values
+	struct wlf_vector3 point_0 = wlf_ray3_point_at_parameter(&ray, 0.0);
+	ASSERT_VECTOR3_EQ(point_0, origin, "Point at t=0 should be origin");
+
+	struct wlf_vector3 point_1 = wlf_ray3_point_at_parameter(&ray, 1.0);
+	struct wlf_vector3 expected_1 = wlf_vector3_make(1.0, 0.0, 0.0);
+	ASSERT_VECTOR3_EQ(point_1, expected_1, "Point at t=1 should be (1,0,0)");
+
+	struct wlf_vector3 point_5 = wlf_ray3_point_at_parameter(&ray, 5.0);
+	struct wlf_vector3 expected_5 = wlf_vector3_make(5.0, 0.0, 0.0);
+	ASSERT_VECTOR3_EQ(point_5, expected_5, "Point at t=5 should be (5,0,0)");
+
+	// Test negative parameter (behind origin)
+	struct wlf_vector3 point_neg = wlf_ray3_point_at_parameter(&ray, -2.0);
+	struct wlf_vector3 expected_neg = wlf_vector3_make(-2.0, 0.0, 0.0);
+	ASSERT_VECTOR3_EQ(point_neg, expected_neg, "Point at t=-2 should be (-2,0,0)");
+}
+
+void test_ray_point_at_parameter_complex(void) {
+	print_test_header("Ray Point At Parameter Complex Tests");
+
+	// Test ray with non-unit direction
+	struct wlf_vector3 origin = wlf_vector3_make(1.0, 2.0, 3.0);
+	struct wlf_vector3 direction = wlf_vector3_make(2.0, -1.0, 1.0);
+	struct wlf_ray3 ray = wlf_ray3_make(origin, direction);
+
+	// Test point calculation
+	struct wlf_vector3 point = wlf_ray3_point_at_parameter(&ray, 2.0);
+	struct wlf_vector3 expected = wlf_vector3_make(5.0, 0.0, 5.0); // (1,2,3) + 2*(2,-1,1)
+	ASSERT_VECTOR3_EQ(point, expected, "Point calculation with non-unit direction");
+
+	// Test fractional parameter
+	struct wlf_vector3 point_half = wlf_ray3_point_at_parameter(&ray, 0.5);
+	struct wlf_vector3 expected_half = wlf_vector3_make(2.0, 1.5, 3.5);
+	ASSERT_VECTOR3_EQ(point_half, expected_half, "Point calculation with fractional parameter");
+}
+
+void test_ray_equality(void) {
+	print_test_header("Ray Equality Tests");
+
+	// Test identical rays
+	struct wlf_vector3 origin1 = wlf_vector3_make(1.0, 2.0, 3.0);
+	struct wlf_vector3 direction1 = wlf_vector3_make(0.0, 1.0, 0.0);
+	struct wlf_ray3 ray1 = wlf_ray3_make(origin1, direction1);
+	struct wlf_ray3 ray2 = wlf_ray3_make(origin1, direction1);
+
+	ASSERT_TRUE(wlf_ray3_equal(&ray1, &ray2), "Identical rays should be equal");
+
+	// Test different origins
+	struct wlf_vector3 origin2 = wlf_vector3_make(2.0, 2.0, 3.0);
+	struct wlf_ray3 ray3 = wlf_ray3_make(origin2, direction1);
+
+	ASSERT_TRUE(!wlf_ray3_equal(&ray1, &ray3), "Rays with different origins should not be equal");
+
+	// Test different directions
+	struct wlf_vector3 direction2 = wlf_vector3_make(1.0, 0.0, 0.0);
+	struct wlf_ray3 ray4 = wlf_ray3_make(origin1, direction2);
+
+	ASSERT_TRUE(!wlf_ray3_equal(&ray1, &ray4), "Rays with different directions should not be equal");
+
+	// Test zero rays
+	ASSERT_TRUE(wlf_ray3_equal(&WLF_RAY_ZERO, &WLF_RAY_ZERO), "Zero ray should equal itself");
+}
+
+void test_ray_nearly_equal(void) {
+	print_test_header("Ray Nearly Equal Tests");
+
+	// Test nearly identical rays
+	struct wlf_vector3 origin1 = wlf_vector3_make(1.0, 2.0, 3.0);
+	struct wlf_vector3 direction1 = wlf_vector3_make(0.0, 1.0, 0.0);
+	struct wlf_ray3 ray1 = wlf_ray3_make(origin1, direction1);
+
+	struct wlf_vector3 origin2 = wlf_vector3_make(1.0 + 1e-10, 2.0, 3.0);
+	struct wlf_vector3 direction2 = wlf_vector3_make(0.0, 1.0 + 1e-10, 0.0);
+	struct wlf_ray3 ray2 = wlf_ray3_make(origin2, direction2);
+
+	ASSERT_TRUE(wlf_ray3_nearly_equal(&ray1, &ray2, 1e-9), "Nearly identical rays should be nearly equal");
+	ASSERT_TRUE(!wlf_ray3_nearly_equal(&ray1, &ray2, 1e-11), "Rays outside epsilon should not be nearly equal");
+
+	// Test exact equality with nearly_equal
+	ASSERT_TRUE(wlf_ray3_nearly_equal(&ray1, &ray1, 1e-15), "Ray should be nearly equal to itself");
+}
+
+void test_ray_string_conversion(void) {
+	print_test_header("Ray String Conversion Tests");
+
+	// Test basic string conversion
+	struct wlf_vector3 origin = wlf_vector3_make(1.0, 2.0, 3.0);
+	struct wlf_vector3 direction = wlf_vector3_make(0.0, 1.0, 0.0);
+	struct wlf_ray3 ray = wlf_ray3_make(origin, direction);
+
+	char* ray_str = wlf_ray3_to_str(&ray);
+
+	ASSERT_TRUE(ray_str != NULL, "String conversion should not return NULL");
+	ASSERT_TRUE(strstr(ray_str, "Ray") != NULL, "String should contain 'Ray'");
+	ASSERT_TRUE(strstr(ray_str, "Origin") != NULL, "String should contain 'Origin'");
+	ASSERT_TRUE(strstr(ray_str, "Direction") != NULL, "String should contain 'Direction'");
+
+	printf("Ray string: %s\n", ray_str);
+
+	// Clean up allocated memory
+	free(ray_str);
+
+	// Test zero ray string conversion
+	char* zero_str = wlf_ray3_to_str(&WLF_RAY_ZERO);
+	ASSERT_TRUE(zero_str != NULL, "Zero ray string conversion should not return NULL");
+	printf("Zero ray string: %s\n", zero_str);
+	free(zero_str);
+}
+
+void test_ray_geometric_properties(void) {
+	print_test_header("Ray Geometric Properties Tests");
+
+	// Test ray parameterization property: P(t) = O + t*D
+	struct wlf_vector3 origin = wlf_vector3_make(2.0, 3.0, 4.0);
+	struct wlf_vector3 direction = wlf_vector3_make(1.0, -1.0, 2.0);
+	struct wlf_ray3 ray = wlf_ray3_make(origin, direction);
+
+	// Verify parameterization for multiple points
+	for (int i = 0; i < 5; i++) {
+		double t = i * 0.5;
+		struct wlf_vector3 point = wlf_ray3_point_at_parameter(&ray, t);
+
+		// Manual calculation: P(t) = O + t*D
+		struct wlf_vector3 scaled_direction = wlf_vector3_multiply(&direction, t);
+		struct wlf_vector3 expected = wlf_vector3_add(&origin, &scaled_direction);
+
+		char msg[100];
+		snprintf(msg, sizeof(msg), "Parameterization should hold for t=%.1f", t);
+		ASSERT_VECTOR3_EQ(point, expected, msg);
+	}
+
+	// Test linearity: P(t1) + P(t2) should relate to P(t1+t2) through direction
+	double t1 = 1.5, t2 = 2.5;
+	struct wlf_vector3 p1 = wlf_ray3_point_at_parameter(&ray, t1);
+	struct wlf_vector3 p_sum = wlf_ray3_point_at_parameter(&ray, t1 + t2);
+
+	// The vector from p1 to p_sum should be t2 * direction
+	struct wlf_vector3 diff = wlf_vector3_subtract(&p_sum, &p1);
+	struct wlf_vector3 expected_diff = wlf_vector3_multiply(&direction, t2);
+	ASSERT_VECTOR3_EQ(diff, expected_diff, "Ray parameterization linearity property");
+}
+
+void test_ray_edge_cases(void) {
+	print_test_header("Ray Edge Cases Tests");
+
+	// Test ray with very large coordinates
+	struct wlf_vector3 large_origin = wlf_vector3_make(1e6, -1e6, 1e8);
+	struct wlf_vector3 small_direction = wlf_vector3_make(1e-6, 1e-8, 1e-10);
+	struct wlf_ray3 large_ray = wlf_ray3_make(large_origin, small_direction);
+
+	struct wlf_vector3 point = wlf_ray3_point_at_parameter(&large_ray, 1e6);
+	ASSERT_TRUE(isfinite(point.x) && isfinite(point.y) && isfinite(point.z),
+				"Point calculation should remain finite for large coordinates");
+
+	// Test ray with zero direction
+	struct wlf_vector3 origin = wlf_vector3_make(1.0, 2.0, 3.0);
+	struct wlf_vector3 zero_direction = WLF_VECTOR3_ZERO;
+	struct wlf_ray3 zero_dir_ray = wlf_ray3_make(origin, zero_direction);
+
+	struct wlf_vector3 point_zero_dir = wlf_ray3_point_at_parameter(&zero_dir_ray, 10.0);
+	ASSERT_VECTOR3_EQ(point_zero_dir, origin, "Ray with zero direction should always return origin");
+
+	// Test very small epsilon
+	struct wlf_ray3 ray1 = wlf_ray3_make(origin, WLF_VECTOR3_UNIT_X);
+	struct wlf_vector3 slightly_different = wlf_vector3_make(1.0 + 1e-15, 2.0, 3.0);
+	struct wlf_ray3 ray2 = wlf_ray3_make(slightly_different, WLF_VECTOR3_UNIT_X);
+
+	ASSERT_TRUE(!wlf_ray3_nearly_equal(&ray1, &ray2, 1e-16),
+				"Very small differences should be detected with tiny epsilon");
+}
+
+void test_ray_normalization_considerations(void) {
+	print_test_header("Ray Normalization Considerations Tests");
+
+	// Note: The API doesn't enforce normalized directions, but we test behavior
+	struct wlf_vector3 origin = WLF_VECTOR3_ZERO;
+
+	// Test with normalized direction
+	struct wlf_vector3 temp_vector = wlf_vector3_make(3.0, 4.0, 0.0);
+	struct wlf_vector3 normalized_dir = wlf_vector3_normalize(&temp_vector);
+	struct wlf_ray3 normalized_ray = wlf_ray3_make(origin, normalized_dir);
+
+	struct wlf_vector3 point_norm = wlf_ray3_point_at_parameter(&normalized_ray, 5.0);
+	double distance_norm = wlf_vector3_magnitude(&point_norm);
+	ASSERT_DOUBLE_EQ(distance_norm, 5.0, "Normalized ray should give expected distance");
+
+	// Test with non-normalized direction
+	struct wlf_vector3 non_normalized_dir = wlf_vector3_make(3.0, 4.0, 0.0); // magnitude = 5
+	struct wlf_ray3 non_normalized_ray = wlf_ray3_make(origin, non_normalized_dir);
+
+	struct wlf_vector3 point_non_norm = wlf_ray3_point_at_parameter(&non_normalized_ray, 1.0);
+	double distance_non_norm = wlf_vector3_magnitude(&point_non_norm);
+	ASSERT_DOUBLE_EQ(distance_non_norm, 5.0, "Non-normalized ray parameter relates to direction magnitude");
+}
+
+int main(void) {
+	printf("Starting wlf_ray3 comprehensive test suite...\n");
+
+	test_ray_creation();
+	test_ray_unit_axes();
+	test_ray_point_at_parameter();
+	test_ray_point_at_parameter_complex();
+	test_ray_equality();
+	test_ray_nearly_equal();
+	test_ray_string_conversion();
+	test_ray_geometric_properties();
+	test_ray_edge_cases();
+	test_ray_normalization_considerations();
+
+	print_test_summary();
+
+	return (passed_tests == test_count) ? 0 : 1;
+}

--- a/examples/math/wlf_rect_test.c
+++ b/examples/math/wlf_rect_test.c
@@ -1,0 +1,255 @@
+#include "wlf/math/wlf_rect.h"
+#include "wlf/utils/wlf_log.h"
+#include <stdlib.h>
+#include <stdint.h>
+
+int main(int argc, char *argv[]) {
+	wlf_log_init(WLF_DEBUG, NULL);
+
+	wlf_log(WLF_INFO, "=== WLF Rectangle Test Suite ===");
+
+	// Test Rectangle Creation
+	wlf_log(WLF_INFO, "\n--- Testing Rectangle Creation ---");
+
+	struct wlf_rect r1 = wlf_rect_make(10, 20, 100, 80);
+	struct wlf_rect r2 = wlf_rect_make(-5, -10, 50, 40);
+	struct wlf_rect zero_rect = WLF_RECT_ZERO;
+	struct wlf_rect unit_rect = WLF_RECT_UNIT;
+
+	char *str1 = wlf_rect_to_str(&r1);
+	char *str2 = wlf_rect_to_str(&r2);
+	char *str_zero = wlf_rect_to_str(&zero_rect);
+	char *str_unit = wlf_rect_to_str(&unit_rect);
+
+	wlf_log(WLF_INFO, "r1: %s", str1);
+	wlf_log(WLF_INFO, "r2: %s", str2);
+	wlf_log(WLF_INFO, "zero: %s", str_zero);
+	wlf_log(WLF_INFO, "unit: %s", str_unit);
+
+	free(str1); free(str2); free(str_zero); free(str_unit);
+
+	// Test creation from point and size
+	struct wlf_point pos = {15, 25};
+	struct wlf_size size = {60, 45};
+	struct wlf_rect r3 = wlf_rect_from_point_size(&pos, &size);
+	char *str3 = wlf_rect_to_str(&r3);
+	wlf_log(WLF_INFO, "From point(15,25) and size(60,45): %s", str3);
+	free(str3);
+
+	// Test creation from two points
+	struct wlf_point p1 = {10, 10};
+	struct wlf_point p2 = {50, 30};
+	struct wlf_rect r4 = wlf_rect_from_points(&p1, &p2);
+	char *str4 = wlf_rect_to_str(&r4);
+	wlf_log(WLF_INFO, "From points(10,10) to (50,30): %s", str4);
+	free(str4);
+
+	// Test Constants
+	wlf_log(WLF_INFO, "\n--- Testing Constants ---");
+
+	char *zero_str = wlf_rect_to_str(&WLF_RECT_ZERO);
+	char *unit_str = wlf_rect_to_str(&WLF_RECT_UNIT);
+	wlf_log(WLF_INFO, "WLF_RECT_ZERO: %s", zero_str);
+	wlf_log(WLF_INFO, "WLF_RECT_UNIT: %s", unit_str);
+	free(zero_str); free(unit_str);
+
+	// Test Equality
+	wlf_log(WLF_INFO, "\n--- Testing Equality ---");
+
+	struct wlf_rect r1_copy = wlf_rect_make(10, 20, 100, 80);
+	wlf_log(WLF_INFO, "r1 == r1_copy: %s", wlf_rect_equal(&r1, &r1_copy) ? "true" : "false");
+	wlf_log(WLF_INFO, "r1 == r2: %s", wlf_rect_equal(&r1, &r2) ? "true" : "false");
+
+	// Test Validity and Empty Checks
+	wlf_log(WLF_INFO, "\n--- Testing Validity and Empty Checks ---");
+
+	struct wlf_rect empty_rect = wlf_rect_make(10, 10, 0, 20);
+	struct wlf_rect invalid_rect = wlf_rect_make(10, 10, -5, 20);
+
+	wlf_log(WLF_INFO, "r1 is empty: %s", wlf_rect_is_empty(&r1) ? "true" : "false");
+	wlf_log(WLF_INFO, "empty_rect is empty: %s", wlf_rect_is_empty(&empty_rect) ? "true" : "false");
+	wlf_log(WLF_INFO, "r1 is valid: %s", wlf_rect_is_valid(&r1) ? "true" : "false");
+	wlf_log(WLF_INFO, "invalid_rect is valid: %s", wlf_rect_is_valid(&invalid_rect) ? "true" : "false");
+
+	// Test Getters
+	wlf_log(WLF_INFO, "\n--- Testing Getters ---");
+
+	struct wlf_point position = wlf_rect_get_position(&r1);
+	struct wlf_size rect_size = wlf_rect_get_size(&r1);
+	struct wlf_point center = wlf_rect_get_center(&r1);
+	struct wlf_point top_left = wlf_rect_get_top_left(&r1);
+	struct wlf_point bottom_right = wlf_rect_get_bottom_right(&r1);
+
+	char *pos_str = wlf_point_to_str(&position);
+	char *size_str = wlf_size_to_str(&rect_size);
+	char *center_str = wlf_point_to_str(&center);
+	char *tl_str = wlf_point_to_str(&top_left);
+	char *br_str = wlf_point_to_str(&bottom_right);
+
+	wlf_log(WLF_INFO, "r1 position: %s", pos_str);
+	wlf_log(WLF_INFO, "r1 size: %s", size_str);
+	wlf_log(WLF_INFO, "r1 center: %s", center_str);
+	wlf_log(WLF_INFO, "r1 top-left: %s", tl_str);
+	wlf_log(WLF_INFO, "r1 bottom-right: %s", br_str);
+
+	free(pos_str); free(size_str); free(center_str); free(tl_str); free(br_str);
+
+	// Test Area and Perimeter
+	wlf_log(WLF_INFO, "\n--- Testing Area and Perimeter ---");
+
+	int area = wlf_rect_area(&r1);
+	int perimeter = wlf_rect_perimeter(&r1);
+	wlf_log(WLF_INFO, "r1 area: %d (expected: 8000)", area);
+	wlf_log(WLF_INFO, "r1 perimeter: %d (expected: 360)", perimeter);
+
+	// Test Transformations
+	wlf_log(WLF_INFO, "\n--- Testing Transformations ---");
+
+	struct wlf_point offset = {5, -3};
+	struct wlf_rect offset_rect = wlf_rect_offset(&r1, &offset);
+	char *offset_str = wlf_rect_to_str(&offset_rect);
+	wlf_log(WLF_INFO, "r1 offset by (5,-3): %s", offset_str);
+	free(offset_str);
+
+	struct wlf_rect inflated = wlf_rect_inflate(&r1, 10, 5);
+	char *inflated_str = wlf_rect_to_str(&inflated);
+	wlf_log(WLF_INFO, "r1 inflated by (10,5): %s", inflated_str);
+	free(inflated_str);
+
+	struct wlf_rect scaled = wlf_rect_scale(&r1, 2.0, 0.5);
+	char *scaled_str = wlf_rect_to_str(&scaled);
+	wlf_log(WLF_INFO, "r1 scaled by (2.0,0.5): %s", scaled_str);
+	free(scaled_str);
+
+	// Test Point Containment
+	wlf_log(WLF_INFO, "\n--- Testing Point Containment ---");
+
+	struct wlf_point test_point1 = {50, 50}; // inside r1
+	struct wlf_point test_point2 = {5, 5};   // outside r1
+	struct wlf_point test_point3 = {10, 20}; // on edge
+
+	wlf_log(WLF_INFO, "r1 contains (50,50): %s", wlf_rect_contains_point(&r1, &test_point1) ? "true" : "false");
+	wlf_log(WLF_INFO, "r1 contains (5,5): %s", wlf_rect_contains_point(&r1, &test_point2) ? "true" : "false");
+	wlf_log(WLF_INFO, "r1 contains (10,20): %s", wlf_rect_contains_point(&r1, &test_point3) ? "true" : "false");
+
+	// Test with double coordinates
+	wlf_log(WLF_INFO, "r1 contains (50.5,50.5): %s", wlf_rect_contains_point_d(&r1, 50.5, 50.5) ? "true" : "false");
+	wlf_log(WLF_INFO, "r1 contains (109.9,99.9): %s", wlf_rect_contains_point_d(&r1, 109.9, 99.9) ? "true" : "false");
+
+	// Test Rectangle Containment
+	wlf_log(WLF_INFO, "\n--- Testing Rectangle Containment ---");
+
+	struct wlf_rect inner = wlf_rect_make(20, 30, 50, 40); // inside r1
+	struct wlf_rect outer = wlf_rect_make(0, 0, 200, 200); // contains r1
+	struct wlf_rect partial = wlf_rect_make(50, 50, 100, 100); // partially overlaps
+
+	char *inner_str = wlf_rect_to_str(&inner);
+	char *outer_str = wlf_rect_to_str(&outer);
+	char *partial_str = wlf_rect_to_str(&partial);
+
+	wlf_log(WLF_INFO, "r1 contains %s: %s", inner_str, wlf_rect_contains_rect(&r1, &inner) ? "true" : "false");
+	wlf_log(WLF_INFO, "%s contains r1: %s", outer_str, wlf_rect_contains_rect(&outer, &r1) ? "true" : "false");
+	wlf_log(WLF_INFO, "r1 contains %s: %s", partial_str, wlf_rect_contains_rect(&r1, &partial) ? "true" : "false");
+
+	free(inner_str); free(outer_str); free(partial_str);
+
+	// Test Intersection
+	wlf_log(WLF_INFO, "\n--- Testing Intersection ---");
+
+	struct wlf_rect rect_a = wlf_rect_make(0, 0, 50, 50);
+	struct wlf_rect rect_b = wlf_rect_make(25, 25, 50, 50);
+	struct wlf_rect no_overlap = wlf_rect_make(100, 100, 20, 20);
+
+	wlf_log(WLF_INFO, "rect_a intersects rect_b: %s", wlf_rect_intersects(&rect_a, &rect_b) ? "true" : "false");
+	wlf_log(WLF_INFO, "rect_a intersects no_overlap: %s", wlf_rect_intersects(&rect_a, &no_overlap) ? "true" : "false");
+
+	struct wlf_rect intersection = wlf_rect_intersection(&rect_a, &rect_b);
+	char *intersection_str = wlf_rect_to_str(&intersection);
+	wlf_log(WLF_INFO, "rect_a ∩ rect_b: %s", intersection_str);
+	free(intersection_str);
+
+	// Test Union
+	wlf_log(WLF_INFO, "\n--- Testing Union ---");
+
+	struct wlf_rect union_rect = wlf_rect_union(&rect_a, &rect_b);
+	char *union_str = wlf_rect_to_str(&union_rect);
+	wlf_log(WLF_INFO, "rect_a ∪ rect_b: %s", union_str);
+	free(union_str);
+
+	// Test Edge Cases
+	wlf_log(WLF_INFO, "\n--- Testing Edge Cases ---");
+
+	// Zero area rectangle
+	struct wlf_rect zero_area = wlf_rect_make(10, 10, 0, 0);
+	wlf_log(WLF_INFO, "Zero area rectangle area: %d", wlf_rect_area(&zero_area));
+	wlf_log(WLF_INFO, "Zero area rectangle is empty: %s", wlf_rect_is_empty(&zero_area) ? "true" : "false");
+
+	// Negative dimensions
+	struct wlf_rect negative = wlf_rect_make(10, 10, -20, -30);
+	wlf_log(WLF_INFO, "Negative rectangle is valid: %s", wlf_rect_is_valid(&negative) ? "true" : "false");
+	wlf_log(WLF_INFO, "Negative rectangle area: %d", wlf_rect_area(&negative));
+
+	// Test large coordinates
+	struct wlf_rect large = wlf_rect_make(1000000, 2000000, 500000, 300000);
+	wlf_log(WLF_INFO, "Large rectangle area: %d", wlf_rect_area(&large));
+
+	char *large_str = wlf_rect_to_str(&large);
+	wlf_log(WLF_INFO, "Large rectangle: %s", large_str);
+	free(large_str);
+	// Test String Parsing
+	wlf_log(WLF_INFO, "\n--- Testing String Parsing ---");
+
+	struct wlf_rect parsed_rect;
+
+	// Test basic format with parentheses (should succeed)
+	if (wlf_rect_from_str("(10,20,100,80)", &parsed_rect)) {
+		char *parsed_str = wlf_rect_to_str(&parsed_rect);
+		wlf_log(WLF_INFO, "Parsed '(10,20,100,80)': %s", parsed_str);
+		free(parsed_str);
+	} else {
+		wlf_log(WLF_ERROR, "Failed to parse '(10,20,100,80)'");
+	}
+
+	// Test format with spaces and parentheses (should succeed)
+	if (wlf_rect_from_str("(5, 15, 30, 25)", &parsed_rect)) {
+		char *parsed_str = wlf_rect_to_str(&parsed_rect);
+		wlf_log(WLF_INFO, "Parsed '(5, 15, 30, 25)': %s", parsed_str);
+		free(parsed_str);
+	} else {
+		wlf_log(WLF_ERROR, "Failed to parse '(5, 15, 30, 25)'");
+	}
+
+	// Test format with whitespace around parentheses (should succeed)
+	if (wlf_rect_from_str("  (0,0,50,50)  ", &parsed_rect)) {
+		char *parsed_str = wlf_rect_to_str(&parsed_rect);
+		wlf_log(WLF_INFO, "Parsed '  (0,0,50,50)  ': %s", parsed_str);
+		free(parsed_str);
+	} else {
+		wlf_log(WLF_ERROR, "Failed to parse '  (0,0,50,50)  '");
+	}
+
+	// Test negative values with parentheses (should succeed)
+	if (wlf_rect_from_str("(-10,-20,100,80)", &parsed_rect)) {
+		char *parsed_str = wlf_rect_to_str(&parsed_rect);
+		wlf_log(WLF_INFO, "Parsed '(-10,-20,100,80)': %s", parsed_str);
+		wlf_log(WLF_INFO, "Is valid: %s", wlf_rect_is_valid(&parsed_rect) ? "true" : "false");
+		free(parsed_str);
+	} else {
+		wlf_log(WLF_ERROR, "Failed to parse '(-10,-20,100,80)'");
+	}
+
+	// Test invalid formats (should all fail)
+	wlf_log(WLF_INFO, "Testing invalid formats (should all fail):");
+	wlf_log(WLF_INFO, "Empty string: %s", wlf_rect_from_str("", &parsed_rect) ? "parsed" : "failed");
+	wlf_log(WLF_INFO, "NULL string: %s", wlf_rect_from_str(NULL, &parsed_rect) ? "parsed" : "failed");
+	wlf_log(WLF_INFO, "No parentheses: %s", wlf_rect_from_str("10,20,100,80", &parsed_rect) ? "parsed" : "failed");
+	wlf_log(WLF_INFO, "Only opening paren: %s", wlf_rect_from_str("(10,20,100,80", &parsed_rect) ? "parsed" : "failed");
+	wlf_log(WLF_INFO, "Only closing paren: %s", wlf_rect_from_str("10,20,100,80)", &parsed_rect) ? "parsed" : "failed");
+	wlf_log(WLF_INFO, "Invalid format: %s", wlf_rect_from_str("(abc,def,ghi,jkl)", &parsed_rect) ? "parsed" : "failed");
+	wlf_log(WLF_INFO, "Too few values: %s", wlf_rect_from_str("(10,20,30)", &parsed_rect) ? "parsed" : "failed");
+	wlf_log(WLF_INFO, "Extra text after: %s", wlf_rect_from_str("(10,20,30,40)extra", &parsed_rect) ? "parsed" : "failed");
+
+	wlf_log(WLF_INFO, "\n=== Rectangle Test Suite Complete ===");
+
+	return 0;
+}

--- a/examples/math/wlf_region_test.c
+++ b/examples/math/wlf_region_test.c
@@ -1,0 +1,62 @@
+#include "wlf/math/wlf_region.h"
+#include "wlf/math/wlf_rect.h"
+#include "wlf/utils/wlf_log.h"
+
+#include <stdint.h>
+
+int main(int argc, char *argv[]) {
+	wlf_log_init(WLF_DEBUG, NULL);
+	struct wlf_region region;
+	wlf_region_init(&region);
+
+	struct wlf_frect r1 = {0, 0, 100, 100};
+	struct wlf_frect r2 = {150, 150, 50, 50};
+	wlf_region_add_rect(&region, &r1);
+	wlf_region_add_rect(&region, &r2);
+
+	char *str = wlf_region_to_str(&region);
+	wlf_log(WLF_INFO, "Region to string:\n%s", str);
+
+	struct wlf_region parsed;
+	if (wlf_region_from_str(str, &parsed)) {
+		char *parsed_str = wlf_region_to_str(&parsed);
+		wlf_log(WLF_INFO, "Parsed region to string: \n%s", parsed_str);
+		free(parsed_str);
+		wlf_region_fini(&parsed);
+	} else {
+		wlf_log(WLF_ERROR, "Failed to parse region from string: %s", str);
+	}
+	free(str);
+
+	// Test region contains point
+	wlf_log(WLF_INFO, "Contains (10,10): %d", wlf_region_contains_point(&region, 10, 10));
+	wlf_log(WLF_INFO, "Contains (199,199): %d", wlf_region_contains_point(&region, 199, 199));
+	wlf_log(WLF_INFO, "Contains (200,200): %d", wlf_region_contains_point(&region, 200, 200));
+
+	// Test intersects rect
+	struct wlf_frect test_rect = {90, 90, 20, 20};
+	struct wlf_region intersection_rect_result;
+	wlf_region_intersects_rect(&region, &test_rect, &intersection_rect_result);
+	if (!wlf_region_is_nil(&intersection_rect_result)) {
+		char *intersection_str = wlf_region_to_str(&intersection_rect_result);
+		wlf_log(WLF_INFO, "Intersection with rect [90,90,20,20]: \n%s", intersection_str);
+		free(intersection_str);
+	} else {
+		wlf_log(WLF_INFO, "No intersection with rect [90,90,20,20]");
+	}
+
+	// Test intersection
+	struct wlf_region intersected_region_result;
+	wlf_region_intersect(&region, &region, &intersected_region_result);
+	if (!wlf_region_is_nil(&intersected_region_result)) {
+		char *intersected_str = wlf_region_to_str(&intersected_region_result);
+		wlf_log(WLF_INFO, "Intersected region: \n%s", intersected_str);
+		free(intersected_str);
+	} else {
+		wlf_log(WLF_INFO, "No intersection found.");
+	}
+
+	wlf_region_fini(&region);
+
+	return 0;
+}

--- a/examples/math/wlf_size_test.c
+++ b/examples/math/wlf_size_test.c
@@ -1,0 +1,193 @@
+#include "wlf/math/wlf_size.h"
+#include "wlf/utils/wlf_log.h"
+
+#include <stdint.h>
+#include <stdlib.h>
+#include <stdio.h>
+
+int main(int argc, char *argv[]) {
+	wlf_log_init(WLF_DEBUG, NULL);
+
+	wlf_log(WLF_INFO, "=== WLF Size Test Suite ===");
+
+	// Test size creation
+	wlf_log(WLF_INFO, "\n--- Testing Size Creation ---");
+	struct wlf_size s1 = (struct wlf_size) {.width = 800, .height = 600};
+	struct wlf_size s2 = (struct wlf_size) {.width = 1920, .height = 1080};
+	struct wlf_size zero_size = (struct wlf_size) {.width = 0, .height = 0};
+	struct wlf_size invalid_size = (struct wlf_size) {.width = -10, .height= 20};
+
+	char *s1_str = wlf_size_to_str(&s1);
+	char *s2_str = wlf_size_to_str(&s2);
+	char *zero_str = wlf_size_to_str(&zero_size);
+	char *invalid_str = wlf_size_to_str(&invalid_size);
+
+	wlf_log(WLF_INFO, "s1: %s", s1_str);
+	wlf_log(WLF_INFO, "s2: %s", s2_str);
+	wlf_log(WLF_INFO, "zero: %s", zero_str);
+	wlf_log(WLF_INFO, "invalid: %s", invalid_str);
+
+	free(s1_str);
+	free(s2_str);
+	free(zero_str);
+	free(invalid_str);
+
+	// Test constants
+	wlf_log(WLF_INFO, "\n--- Testing Constants ---");
+	char *zero_const_str = wlf_size_to_str(&WLF_SIZE_ZERO);
+	char *unit_str = wlf_size_to_str(&WLF_SIZE_UNIT);
+
+	wlf_log(WLF_INFO, "WLF_SIZE_ZERO: %s", zero_const_str);
+	wlf_log(WLF_INFO, "WLF_SIZE_UNIT: %s", unit_str);
+
+	free(zero_const_str);
+	free(unit_str);
+
+	// Test equality
+	wlf_log(WLF_INFO, "\n--- Testing Equality ---");
+	struct wlf_size s1_copy = (struct wlf_size) {.width = 800, .height = 600};
+	bool equal = wlf_size_equal(&s1, &s1_copy);
+	bool not_equal = wlf_size_equal(&s1, &s2);
+	wlf_log(WLF_INFO, "s1 == s1_copy: %s", equal ? "true" : "false");
+	wlf_log(WLF_INFO, "s1 == s2: %s", not_equal ? "true" : "false");
+
+	// Test validity and emptiness checks
+	wlf_log(WLF_INFO, "\n--- Testing Validity and Emptiness ---");
+	bool s1_valid = wlf_size_is_valid(&s1);
+	bool s1_empty = wlf_size_is_empty(&s1);
+	bool zero_valid = wlf_size_is_valid(&zero_size);
+	bool zero_empty = wlf_size_is_empty(&zero_size);
+	bool invalid_valid = wlf_size_is_valid(&invalid_size);
+	bool invalid_empty = wlf_size_is_empty(&invalid_size);
+
+	wlf_log(WLF_INFO, "s1 is valid: %s, is empty: %s",
+		s1_valid ? "true" : "false", s1_empty ? "true" : "false");
+	wlf_log(WLF_INFO, "zero is valid: %s, is empty: %s",
+		zero_valid ? "true" : "false", zero_empty ? "true" : "false");
+	wlf_log(WLF_INFO, "invalid is valid: %s, is empty: %s",
+		invalid_valid ? "true" : "false", invalid_empty ? "true" : "false");
+
+	// Test arithmetic operations
+	wlf_log(WLF_INFO, "\n--- Testing Arithmetic Operations ---");
+	struct wlf_size sum = wlf_size_add(&s1, &s2);
+	struct wlf_size diff = wlf_size_subtract(&s2, &s1);
+	struct wlf_size scaled = wlf_size_multiply(&s1, 2);
+	struct wlf_size divided = wlf_size_divide(&s1, 2);
+
+	char *sum_str = wlf_size_to_str(&sum);
+	char *diff_str = wlf_size_to_str(&diff);
+	char *scaled_str = wlf_size_to_str(&scaled);
+	char *divided_str = wlf_size_to_str(&divided);
+
+	wlf_log(WLF_INFO, "s1 + s2 = %s", sum_str);
+	wlf_log(WLF_INFO, "s2 - s1 = %s", diff_str);
+	wlf_log(WLF_INFO, "s1 * 2 = %s", scaled_str);
+	wlf_log(WLF_INFO, "s1 / 2 = %s", divided_str);
+
+	free(sum_str);
+	free(diff_str);
+	free(scaled_str);
+	free(divided_str);
+
+	// Test area calculation
+	wlf_log(WLF_INFO, "\n--- Testing Area Calculation ---");
+	int s1_area = wlf_size_area(&s1);
+	int s2_area = wlf_size_area(&s2);
+	int zero_area = wlf_size_area(&zero_size);
+
+	wlf_log(WLF_INFO, "Area of s1 (800x600): %d", s1_area);
+	wlf_log(WLF_INFO, "Area of s2 (1920x1080): %d", s2_area);
+	wlf_log(WLF_INFO, "Area of zero size: %d", zero_area);
+
+	// Test common screen resolutions
+	wlf_log(WLF_INFO, "\n--- Testing Common Screen Resolutions ---");
+	struct wlf_size vga = (struct wlf_size) {.width = 640, .height = 480};
+	struct wlf_size hd = (struct wlf_size) {.width = 1280, .height = 720};
+	struct wlf_size full_hd = (struct wlf_size) {.width = 1920, .height = 1080};
+	struct wlf_size quad_hd = (struct wlf_size) {.width = 2560, .height = 1440};
+	struct wlf_size ultra_hd = (struct wlf_size) {.width = 3840, .height = 2160};
+
+	char *vga_str = wlf_size_to_str(&vga);
+	char *hd_str = wlf_size_to_str(&hd);
+	char *full_hd_str = wlf_size_to_str(&full_hd);
+	char *quad_hd_str = wlf_size_to_str(&quad_hd);
+	char *ultra_hd_str = wlf_size_to_str(&ultra_hd);
+
+	wlf_log(WLF_INFO, "VGA: %s (area: %d)", vga_str, wlf_size_area(&vga));
+	wlf_log(WLF_INFO, "HD: %s (area: %d)", hd_str, wlf_size_area(&hd));
+	wlf_log(WLF_INFO, "Full HD: %s (area: %d)", full_hd_str, wlf_size_area(&full_hd));
+	wlf_log(WLF_INFO, "Quad HD: %s (area: %d)", quad_hd_str, wlf_size_area(&quad_hd));
+	wlf_log(WLF_INFO, "Ultra HD: %s (area: %d)", ultra_hd_str, wlf_size_area(&ultra_hd));
+
+	free(vga_str);
+	free(hd_str);
+	free(full_hd_str);
+	free(quad_hd_str);
+	free(ultra_hd_str);
+
+	// Test edge cases
+	wlf_log(WLF_INFO, "\n--- Testing Edge Cases ---");
+
+	// Division by zero
+	struct wlf_size div_by_zero = wlf_size_divide(&s1, 0);
+	char *div_by_zero_str = wlf_size_to_str(&div_by_zero);
+	wlf_log(WLF_INFO, "Division by zero result: %s", div_by_zero_str);
+	free(div_by_zero_str);
+
+	// Negative operations
+	struct wlf_size neg_scaled = wlf_size_multiply(&s1, -1);
+	char *neg_scaled_str = wlf_size_to_str(&neg_scaled);
+	wlf_log(WLF_INFO, "s1 * -1 = %s", neg_scaled_str);
+	free(neg_scaled_str);
+
+	// Large numbers
+	struct wlf_size large = (struct wlf_size) {.width = 100000, .height = 100000};
+	int large_area = wlf_size_area(&large);
+	char *large_str = wlf_size_to_str(&large);
+	wlf_log(WLF_INFO, "Large size: %s (area: %d)", large_str, large_area);
+	free(large_str);
+
+	// Test aspect ratios
+	wlf_log(WLF_INFO, "\n--- Testing Aspect Ratios ---");
+	struct wlf_size square = (struct wlf_size) {.width = 512, .height = 512};
+	struct wlf_size wide = (struct wlf_size) {.width = 1920, .height = 800};
+	struct wlf_size tall = (struct wlf_size) {.width = 600, .height = 1200};
+
+	char *square_str = wlf_size_to_str(&square);
+	char *wide_str = wlf_size_to_str(&wide);
+	char *tall_str = wlf_size_to_str(&tall);
+
+	wlf_log(WLF_INFO, "Square: %s (ratio: %.2f)", square_str, (double)square.width / square.height);
+	wlf_log(WLF_INFO, "Wide: %s (ratio: %.2f)", wide_str, (double)wide.width / wide.height);
+	wlf_log(WLF_INFO, "Tall: %s (ratio: %.2f)", tall_str, (double)tall.width / tall.height);
+
+	free(square_str);
+	free(wide_str);
+	free(tall_str);
+
+	// Test scaling operations
+	wlf_log(WLF_INFO, "\n--- Testing Scaling Operations ---");
+	struct wlf_size original = (struct wlf_size) {.width = 100, .height = 50};
+	struct wlf_size double_size = wlf_size_multiply(&original, 2);
+	struct wlf_size triple_size = wlf_size_multiply(&original, 3);
+	struct wlf_size half_size = wlf_size_divide(&original, 2);
+
+	char *original_str = wlf_size_to_str(&original);
+	char *double_str = wlf_size_to_str(&double_size);
+	char *triple_str = wlf_size_to_str(&triple_size);
+	char *half_str = wlf_size_to_str(&half_size);
+
+	wlf_log(WLF_INFO, "Original: %s", original_str);
+	wlf_log(WLF_INFO, "2x scale: %s", double_str);
+	wlf_log(WLF_INFO, "3x scale: %s", triple_str);
+	wlf_log(WLF_INFO, "0.5x scale: %s", half_str);
+
+	free(original_str);
+	free(double_str);
+	free(triple_str);
+	free(half_str);
+
+	wlf_log(WLF_INFO, "\n=== Size Test Suite Complete ===");
+
+	return 0;
+}

--- a/examples/math/wlf_vector2_test.c
+++ b/examples/math/wlf_vector2_test.c
@@ -1,0 +1,252 @@
+#include "wlf/math/wlf_vector2.h"
+#include "wlf/utils/wlf_log.h"
+#include <stdlib.h>
+#include <stdint.h>
+#include <math.h>
+
+int main(int argc, char *argv[]) {
+	wlf_log_init(WLF_DEBUG, NULL);
+
+	wlf_log(WLF_INFO, "=== WLF Vector2 Test Suite ===");
+
+	// Test Vector2 Creation
+	wlf_log(WLF_INFO, "\n--- Testing Vector2 Creation ---");
+
+	struct wlf_vector2 v1 = (struct wlf_vector2) {.u = 3.0, .v = 4.0};
+	struct wlf_vector2 v2 = (struct wlf_vector2) {.u = -2.5, .v = 1.5};
+	struct wlf_vector2 zero_vec = WLF_VECTOR2_ZERO;
+	struct wlf_vector2 unit_u = WLF_VECTOR2_UNIT_U;
+	struct wlf_vector2 unit_v = WLF_VECTOR2_UNIT_V;
+
+	char *str1 = wlf_vector2_to_str(&v1);
+	char *str2 = wlf_vector2_to_str(&v2);
+	char *str_zero = wlf_vector2_to_str(&zero_vec);
+	char *str_unit_u = wlf_vector2_to_str(&unit_u);
+	char *str_unit_v = wlf_vector2_to_str(&unit_v);
+
+	wlf_log(WLF_INFO, "v1: %s", str1);
+	wlf_log(WLF_INFO, "v2: %s", str2);
+	wlf_log(WLF_INFO, "zero: %s", str_zero);
+	wlf_log(WLF_INFO, "unit_u: %s", str_unit_u);
+	wlf_log(WLF_INFO, "unit_v: %s", str_unit_v);
+
+	free(str1); free(str2); free(str_zero); free(str_unit_u); free(str_unit_v);
+
+	// Test Constants
+	wlf_log(WLF_INFO, "\n--- Testing Constants ---");
+
+	char *zero_str = wlf_vector2_to_str(&WLF_VECTOR2_ZERO);
+	char *unit_u_str = wlf_vector2_to_str(&WLF_VECTOR2_UNIT_U);
+	char *unit_v_str = wlf_vector2_to_str(&WLF_VECTOR2_UNIT_V);
+
+	wlf_log(WLF_INFO, "WLF_VECTOR2_ZERO: %s", zero_str);
+	wlf_log(WLF_INFO, "WLF_VECTOR2_UNIT_U: %s", unit_u_str);
+	wlf_log(WLF_INFO, "WLF_VECTOR2_UNIT_V: %s", unit_v_str);
+
+	free(zero_str); free(unit_u_str); free(unit_v_str);
+
+	// Test Equality
+	wlf_log(WLF_INFO, "\n--- Testing Equality ---");
+
+	struct wlf_vector2 v1_copy = (struct wlf_vector2) {.u = 3.0, .v = 4.0};
+	struct wlf_vector2 v1_approx = (struct wlf_vector2) {.u = 3.00001, .v = 4.00001};
+
+	wlf_log(WLF_INFO, "v1 == v1_copy (exact): %s", wlf_vector2_equal(&v1, &v1_copy) ? "true" : "false");
+	wlf_log(WLF_INFO, "v1 == v2 (exact): %s", wlf_vector2_equal(&v1, &v2) ? "true" : "false");
+	wlf_log(WLF_INFO, "v1 ≈ v1_approx (ε=0.001): %s", wlf_vector2_nearly_equal(&v1, &v1_approx, 0.001) ? "true" : "false");
+	wlf_log(WLF_INFO, "v1 ≈ v1_approx (ε=0.000001): %s", wlf_vector2_nearly_equal(&v1, &v1_approx, 0.000001) ? "true" : "false");
+
+	// Test Arithmetic Operations
+	wlf_log(WLF_INFO, "\n--- Testing Arithmetic Operations ---");
+
+	struct wlf_vector2 add_result = wlf_vector2_add(&v1, &v2);
+	struct wlf_vector2 sub_result = wlf_vector2_subtract(&v1, &v2);
+	struct wlf_vector2 mul_result = wlf_vector2_multiply(&v1, 2.5);
+	struct wlf_vector2 div_result = wlf_vector2_divide(&v1, 2.0);
+
+	char *add_str = wlf_vector2_to_str(&add_result);
+	char *sub_str = wlf_vector2_to_str(&sub_result);
+	char *mul_str = wlf_vector2_to_str(&mul_result);
+	char *div_str = wlf_vector2_to_str(&div_result);
+
+	wlf_log(WLF_INFO, "v1 + v2 = %s", add_str);
+	wlf_log(WLF_INFO, "v1 - v2 = %s", sub_str);
+	wlf_log(WLF_INFO, "v1 * 2.5 = %s", mul_str);
+	wlf_log(WLF_INFO, "v1 / 2.0 = %s", div_str);
+
+	free(add_str); free(sub_str); free(mul_str); free(div_str);
+
+	// Test Vector Properties
+	wlf_log(WLF_INFO, "\n--- Testing Vector Properties ---");
+
+	double v1_magnitude = wlf_vector2_magnitude(&v1);
+	double v2_magnitude = wlf_vector2_magnitude(&v2);
+	double zero_magnitude = wlf_vector2_magnitude(&WLF_VECTOR2_ZERO);
+	double unit_u_magnitude = wlf_vector2_magnitude(&WLF_VECTOR2_UNIT_U);
+
+	wlf_log(WLF_INFO, "v1 magnitude: %.3f (expected: 5.000)", v1_magnitude);
+	wlf_log(WLF_INFO, "v2 magnitude: %.3f", v2_magnitude);
+	wlf_log(WLF_INFO, "zero magnitude: %.3f", zero_magnitude);
+	wlf_log(WLF_INFO, "unit_u magnitude: %.3f (expected: 1.000)", unit_u_magnitude);
+
+	// Test Dot Product
+	wlf_log(WLF_INFO, "\n--- Testing Dot Product ---");
+
+	double dot_v1_v2 = wlf_vector2_dot(&v1, &v2);
+	double dot_v1_unit_u = wlf_vector2_dot(&v1, &WLF_VECTOR2_UNIT_U);
+	double dot_v1_unit_v = wlf_vector2_dot(&v1, &WLF_VECTOR2_UNIT_V);
+	double dot_v1_self = wlf_vector2_dot(&v1, &v1);
+
+	wlf_log(WLF_INFO, "v1 · v2 = %.3f", dot_v1_v2);
+	wlf_log(WLF_INFO, "v1 · unit_u = %.3f (should equal v1.u = 3.000)", dot_v1_unit_u);
+	wlf_log(WLF_INFO, "v1 · unit_v = %.3f (should equal v1.v = 4.000)", dot_v1_unit_v);
+	wlf_log(WLF_INFO, "v1 · v1 = %.3f (should equal |v1|² = 25.000)", dot_v1_self);
+
+	// Test Normalization
+	wlf_log(WLF_INFO, "\n--- Testing Normalization ---");
+
+	struct wlf_vector2 v1_normalized = wlf_vector2_normalize(&v1);
+	struct wlf_vector2 v2_normalized = wlf_vector2_normalize(&v2);
+	struct wlf_vector2 zero_normalized = wlf_vector2_normalize(&WLF_VECTOR2_ZERO);
+
+	char *v1_norm_str = wlf_vector2_to_str(&v1_normalized);
+	char *v2_norm_str = wlf_vector2_to_str(&v2_normalized);
+	char *zero_norm_str = wlf_vector2_to_str(&zero_normalized);
+
+	wlf_log(WLF_INFO, "v1 normalized: %s", v1_norm_str);
+	wlf_log(WLF_INFO, "v2 normalized: %s", v2_norm_str);
+	wlf_log(WLF_INFO, "zero normalized: %s", zero_norm_str);
+
+	// Check normalized vector magnitudes
+	double v1_norm_mag = wlf_vector2_magnitude(&v1_normalized);
+	double v2_norm_mag = wlf_vector2_magnitude(&v2_normalized);
+	wlf_log(WLF_INFO, "v1_normalized magnitude: %.6f (should be 1.000000)", v1_norm_mag);
+	wlf_log(WLF_INFO, "v2_normalized magnitude: %.6f (should be 1.000000)", v2_norm_mag);
+
+	free(v1_norm_str); free(v2_norm_str); free(zero_norm_str);
+
+	// Test Mathematical Properties
+	wlf_log(WLF_INFO, "\n--- Testing Mathematical Properties ---");
+
+	// Test orthogonal vectors (90° angle)
+	struct wlf_vector2 ortho1 = (struct wlf_vector2) {.u = 1.0, .v = 0.0};
+	struct wlf_vector2 ortho2 = (struct wlf_vector2) {.u = 0.0, .v = 1.0};
+	double ortho_dot = wlf_vector2_dot(&ortho1, &ortho2);
+	wlf_log(WLF_INFO, "Orthogonal vectors dot product: %.3f (should be 0.000)", ortho_dot);
+
+	// Test parallel vectors
+	struct wlf_vector2 parallel1 = (struct wlf_vector2) {.u = 2.0, .v = 3.0};
+	struct wlf_vector2 parallel2 = (struct wlf_vector2) {.u = 4.0, .v = 6.0};
+	double parallel_dot = wlf_vector2_dot(&parallel1, &parallel2);
+	double parallel1_mag = wlf_vector2_magnitude(&parallel1);
+	double parallel2_mag = wlf_vector2_magnitude(&parallel2);
+	double expected_parallel_dot = parallel1_mag * parallel2_mag;
+	wlf_log(WLF_INFO, "Parallel vectors dot product: %.3f", parallel_dot);
+	wlf_log(WLF_INFO, "Expected (|v1| * |v2|): %.3f", expected_parallel_dot);
+
+	// Test anti-parallel vectors (180° angle)
+	struct wlf_vector2 anti1 = (struct wlf_vector2) {.u = 1.0, .v = 2.0};
+	struct wlf_vector2 anti2 = (struct wlf_vector2) {.u = -2.0, .v = -4.0};
+	double anti_dot = wlf_vector2_dot(&anti1, &anti2);
+	double anti1_mag = wlf_vector2_magnitude(&anti1);
+	double anti2_mag = wlf_vector2_magnitude(&anti2);
+	double expected_anti_dot = -anti1_mag * anti2_mag;
+	wlf_log(WLF_INFO, "Anti-parallel vectors dot product: %.3f", anti_dot);
+	wlf_log(WLF_INFO, "Expected (-|v1| * |v2|): %.3f", expected_anti_dot);
+
+	// Test Edge Cases
+	wlf_log(WLF_INFO, "\n--- Testing Edge Cases ---");
+
+	// Very small numbers
+	struct wlf_vector2 tiny = (struct wlf_vector2) {.u = 1e-10, .v = 1e-10};
+	double tiny_mag = wlf_vector2_magnitude(&tiny);
+	struct wlf_vector2 tiny_norm = wlf_vector2_normalize(&tiny);
+	char *tiny_str = wlf_vector2_to_str(&tiny);
+	char *tiny_norm_str = wlf_vector2_to_str(&tiny_norm);
+	wlf_log(WLF_INFO, "Tiny vector: %s", tiny_str);
+	wlf_log(WLF_INFO, "Tiny magnitude: %.12e", tiny_mag);
+	wlf_log(WLF_INFO, "Tiny normalized: %s", tiny_norm_str);
+	free(tiny_str); free(tiny_norm_str);
+
+	// Very large numbers
+	struct wlf_vector2 large = (struct wlf_vector2) {.u = 1e6, .v = 1e6};
+	double large_mag = wlf_vector2_magnitude(&large);
+	struct wlf_vector2 large_norm = wlf_vector2_normalize(&large);
+	char *large_str = wlf_vector2_to_str(&large);
+	char *large_norm_str = wlf_vector2_to_str(&large_norm);
+	wlf_log(WLF_INFO, "Large vector: %s", large_str);
+	wlf_log(WLF_INFO, "Large magnitude: %.3e", large_mag);
+	wlf_log(WLF_INFO, "Large normalized: %s", large_norm_str);
+	free(large_str); free(large_norm_str);
+
+	// Test Epsilon Comparison
+	wlf_log(WLF_INFO, "\n--- Testing Epsilon Comparison ---");
+
+	struct wlf_vector2 base = (struct wlf_vector2) {.u = 1.0, .v = 2.0};
+	struct wlf_vector2 tiny_diff = (struct wlf_vector2) {.u = 1.0000001, .v = 2.0000001};
+	struct wlf_vector2 big_diff = (struct wlf_vector2) {.u = 1.1, .v = 2.1};
+
+	double epsilons[] = {1e-10, 1e-6, 1e-3, 0.01, 0.1, 1.0};
+
+	for (int i = 0; i < 6; i++) {
+		double eps = epsilons[i];
+		bool tiny_equal = wlf_vector2_nearly_equal(&base, &tiny_diff, eps);
+		bool big_equal = wlf_vector2_nearly_equal(&base, &big_diff, eps);
+		wlf_log(WLF_INFO, "ε=%.0e: tiny_diff=%s, big_diff=%s", eps,
+				tiny_equal ? "true" : "false", big_equal ? "true" : "false");
+	}
+
+	// Test Vector Algebra Properties
+	wlf_log(WLF_INFO, "\n--- Testing Vector Algebra Properties ---");
+
+	// Commutativity: a + b = b + a
+	struct wlf_vector2 comm1 = wlf_vector2_add(&v1, &v2);
+	struct wlf_vector2 comm2 = wlf_vector2_add(&v2, &v1);
+	bool commutative = wlf_vector2_equal(&comm1, &comm2);
+	wlf_log(WLF_INFO, "Addition commutative: %s", commutative ? "true" : "false");
+
+	// Associativity: (a + b) + c = a + (b + c)
+	struct wlf_vector2 v3 = (struct wlf_vector2) {.u = 1.0, .v = -1.0};
+	struct wlf_vector2 assoc1_temp = wlf_vector2_add(&v1, &v2);
+	struct wlf_vector2 assoc1 = wlf_vector2_add(&assoc1_temp, &v3);
+	struct wlf_vector2 assoc2_temp = wlf_vector2_add(&v2, &v3);
+	struct wlf_vector2 assoc2 = wlf_vector2_add(&v1, &assoc2_temp);
+	bool associative = wlf_vector2_nearly_equal(&assoc1, &assoc2, 1e-10);
+	wlf_log(WLF_INFO, "Addition associative: %s", associative ? "true" : "false");
+
+	// Identity: v + 0 = v
+	struct wlf_vector2 identity = wlf_vector2_add(&v1, &WLF_VECTOR2_ZERO);
+	bool identity_prop = wlf_vector2_equal(&v1, &identity);
+	wlf_log(WLF_INFO, "Zero identity: %s", identity_prop ? "true" : "false");
+
+	// Scalar multiplication distributivity: k(a + b) = ka + kb
+	double k = 3.5;
+	struct wlf_vector2 dist1_temp = wlf_vector2_add(&v1, &v2);
+	struct wlf_vector2 dist1 = wlf_vector2_multiply(&dist1_temp, k);
+	struct wlf_vector2 dist2_temp1 = wlf_vector2_multiply(&v1, k);
+	struct wlf_vector2 dist2_temp2 = wlf_vector2_multiply(&v2, k);
+	struct wlf_vector2 dist2 = wlf_vector2_add(&dist2_temp1, &dist2_temp2);
+	bool distributive = wlf_vector2_nearly_equal(&dist1, &dist2, 1e-10);
+	wlf_log(WLF_INFO, "Scalar multiplication distributive: %s", distributive ? "true" : "false");
+
+	// Test Known Vector Calculations
+	wlf_log(WLF_INFO, "\n--- Testing Known Vector Calculations ---");
+
+	// 3-4-5 right triangle
+	struct wlf_vector2 vec_3_4 = (struct wlf_vector2) {.u =3.0, .v = 4.0};
+	double mag_3_4 = wlf_vector2_magnitude(&vec_3_4);
+	wlf_log(WLF_INFO, "Vector(3,4) magnitude: %.3f (expected: 5.000)", mag_3_4);
+
+	// 45-degree angle vectors
+	struct wlf_vector2 vec_45_1 = (struct wlf_vector2) {.u = 1.0, .v = 1.0};
+	struct wlf_vector2 vec_45_2 = (struct wlf_vector2) { .u = 1.0, .v = 0.0};
+	double dot_45 = wlf_vector2_dot(&vec_45_1, &vec_45_2);
+	double mag_45_1 = wlf_vector2_magnitude(&vec_45_1);
+	double mag_45_2 = wlf_vector2_magnitude(&vec_45_2);
+	double cos_45 = dot_45 / (mag_45_1 * mag_45_2);
+	wlf_log(WLF_INFO, "45° angle cosine: %.6f (expected: 0.707107)", cos_45);
+
+	wlf_log(WLF_INFO, "\n=== Vector2 Test Suite Complete ===");
+
+	return 0;
+}

--- a/examples/math/wlf_vector3_test.c
+++ b/examples/math/wlf_vector3_test.c
@@ -1,0 +1,318 @@
+#include "wlf/math/wlf_vector3.h"
+#include "wlf/utils/wlf_log.h"
+#include <stdlib.h>
+#include <stdint.h>
+#include <math.h>
+
+int main(int argc, char *argv[]) {
+	wlf_log_init(WLF_DEBUG, NULL);
+
+	wlf_log(WLF_INFO, "=== WLF Vector3 Test Suite ===");
+
+	// Test Vector3 Creation
+	wlf_log(WLF_INFO, "\n--- Testing Vector3 Creation ---");
+
+	struct wlf_vector3 v1 = wlf_vector3_make(3.0, 4.0, 5.0);
+	struct wlf_vector3 v2 = wlf_vector3_make(-2.5, 1.5, -3.0);
+	struct wlf_vector3 zero_vec = WLF_VECTOR3_ZERO;
+	struct wlf_vector3 unit_x = WLF_VECTOR3_UNIT_X;
+	struct wlf_vector3 unit_y = WLF_VECTOR3_UNIT_Y;
+	struct wlf_vector3 unit_z = WLF_VECTOR3_UNIT_Z;
+
+	char *str1 = wlf_vector3_to_str(&v1);
+	char *str2 = wlf_vector3_to_str(&v2);
+	char *str_zero = wlf_vector3_to_str(&zero_vec);
+	char *str_unit_x = wlf_vector3_to_str(&unit_x);
+	char *str_unit_y = wlf_vector3_to_str(&unit_y);
+	char *str_unit_z = wlf_vector3_to_str(&unit_z);
+
+	wlf_log(WLF_INFO, "v1: %s", str1);
+	wlf_log(WLF_INFO, "v2: %s", str2);
+	wlf_log(WLF_INFO, "zero: %s", str_zero);
+	wlf_log(WLF_INFO, "unit_x: %s", str_unit_x);
+	wlf_log(WLF_INFO, "unit_y: %s", str_unit_y);
+	wlf_log(WLF_INFO, "unit_z: %s", str_unit_z);
+
+	free(str1); free(str2); free(str_zero);
+	free(str_unit_x); free(str_unit_y); free(str_unit_z);
+
+	// Test Constants
+	wlf_log(WLF_INFO, "\n--- Testing Constants ---");
+
+	char *zero_str = wlf_vector3_to_str(&WLF_VECTOR3_ZERO);
+	char *unit_x_str = wlf_vector3_to_str(&WLF_VECTOR3_UNIT_X);
+	char *unit_y_str = wlf_vector3_to_str(&WLF_VECTOR3_UNIT_Y);
+	char *unit_z_str = wlf_vector3_to_str(&WLF_VECTOR3_UNIT_Z);
+
+	wlf_log(WLF_INFO, "WLF_VECTOR3_ZERO: %s", zero_str);
+	wlf_log(WLF_INFO, "WLF_VECTOR3_UNIT_X: %s", unit_x_str);
+	wlf_log(WLF_INFO, "WLF_VECTOR3_UNIT_Y: %s", unit_y_str);
+	wlf_log(WLF_INFO, "WLF_VECTOR3_UNIT_Z: %s", unit_z_str);
+
+	free(zero_str); free(unit_x_str); free(unit_y_str); free(unit_z_str);
+
+	// Test Equality
+	wlf_log(WLF_INFO, "\n--- Testing Equality ---");
+
+	struct wlf_vector3 v1_copy = wlf_vector3_make(3.0, 4.0, 5.0);
+	struct wlf_vector3 v1_approx = wlf_vector3_make(3.00001, 4.00001, 5.00001);
+
+	wlf_log(WLF_INFO, "v1 == v1_copy (exact): %s", wlf_vector3_equal(&v1, &v1_copy) ? "true" : "false");
+	wlf_log(WLF_INFO, "v1 == v2 (exact): %s", wlf_vector3_equal(&v1, &v2) ? "true" : "false");
+	wlf_log(WLF_INFO, "v1 ≈ v1_approx (ε=0.001): %s", wlf_vector3_nearly_equal(&v1, &v1_approx, 0.001) ? "true" : "false");
+	wlf_log(WLF_INFO, "v1 ≈ v1_approx (ε=0.000001): %s", wlf_vector3_nearly_equal(&v1, &v1_approx, 0.000001) ? "true" : "false");
+
+	// Test Arithmetic Operations
+	wlf_log(WLF_INFO, "\n--- Testing Arithmetic Operations ---");
+
+	struct wlf_vector3 add_result = wlf_vector3_add(&v1, &v2);
+	struct wlf_vector3 sub_result = wlf_vector3_subtract(&v1, &v2);
+	struct wlf_vector3 mul_result = wlf_vector3_multiply(&v1, 2.5);
+	struct wlf_vector3 div_result = wlf_vector3_divide(&v1, 2.0);
+
+	char *add_str = wlf_vector3_to_str(&add_result);
+	char *sub_str = wlf_vector3_to_str(&sub_result);
+	char *mul_str = wlf_vector3_to_str(&mul_result);
+	char *div_str = wlf_vector3_to_str(&div_result);
+
+	wlf_log(WLF_INFO, "v1 + v2 = %s", add_str);
+	wlf_log(WLF_INFO, "v1 - v2 = %s", sub_str);
+	wlf_log(WLF_INFO, "v1 * 2.5 = %s", mul_str);
+	wlf_log(WLF_INFO, "v1 / 2.0 = %s", div_str);
+
+	free(add_str); free(sub_str); free(mul_str); free(div_str);
+
+	// Test Vector Properties
+	wlf_log(WLF_INFO, "\n--- Testing Vector Properties ---");
+
+	double v1_magnitude = wlf_vector3_magnitude(&v1);
+	double v2_magnitude = wlf_vector3_magnitude(&v2);
+	double zero_magnitude = wlf_vector3_magnitude(&WLF_VECTOR3_ZERO);
+	double unit_x_magnitude = wlf_vector3_magnitude(&WLF_VECTOR3_UNIT_X);
+
+	wlf_log(WLF_INFO, "v1 magnitude: %.3f (expected: 7.071)", v1_magnitude);
+	wlf_log(WLF_INFO, "v2 magnitude: %.3f", v2_magnitude);
+	wlf_log(WLF_INFO, "zero magnitude: %.3f", zero_magnitude);
+	wlf_log(WLF_INFO, "unit_x magnitude: %.3f (expected: 1.000)", unit_x_magnitude);
+
+	// Test Dot Product
+	wlf_log(WLF_INFO, "\n--- Testing Dot Product ---");
+
+	double dot_v1_v2 = wlf_vector3_dot(&v1, &v2);
+	double dot_v1_unit_x = wlf_vector3_dot(&v1, &WLF_VECTOR3_UNIT_X);
+	double dot_v1_unit_y = wlf_vector3_dot(&v1, &WLF_VECTOR3_UNIT_Y);
+	double dot_v1_unit_z = wlf_vector3_dot(&v1, &WLF_VECTOR3_UNIT_Z);
+	double dot_v1_self = wlf_vector3_dot(&v1, &v1);
+
+	wlf_log(WLF_INFO, "v1 · v2 = %.3f", dot_v1_v2);
+	wlf_log(WLF_INFO, "v1 · unit_x = %.3f (should equal v1.x = 3.000)", dot_v1_unit_x);
+	wlf_log(WLF_INFO, "v1 · unit_y = %.3f (should equal v1.y = 4.000)", dot_v1_unit_y);
+	wlf_log(WLF_INFO, "v1 · unit_z = %.3f (should equal v1.z = 5.000)", dot_v1_unit_z);
+	wlf_log(WLF_INFO, "v1 · v1 = %.3f (should equal |v1|² = 50.000)", dot_v1_self);
+
+	// Test Cross Product
+	wlf_log(WLF_INFO, "\n--- Testing Cross Product ---");
+
+	struct wlf_vector3 cross_v1_v2 = wlf_vector3_cross(&v1, &v2);
+	struct wlf_vector3 cross_unit_x_unit_y = wlf_vector3_cross(&WLF_VECTOR3_UNIT_X, &WLF_VECTOR3_UNIT_Y);
+	struct wlf_vector3 cross_unit_y_unit_z = wlf_vector3_cross(&WLF_VECTOR3_UNIT_Y, &WLF_VECTOR3_UNIT_Z);
+	struct wlf_vector3 cross_unit_z_unit_x = wlf_vector3_cross(&WLF_VECTOR3_UNIT_Z, &WLF_VECTOR3_UNIT_X);
+
+	char *cross_v1_v2_str = wlf_vector3_to_str(&cross_v1_v2);
+	char *cross_xy_str = wlf_vector3_to_str(&cross_unit_x_unit_y);
+	char *cross_yz_str = wlf_vector3_to_str(&cross_unit_y_unit_z);
+	char *cross_zx_str = wlf_vector3_to_str(&cross_unit_z_unit_x);
+
+	wlf_log(WLF_INFO, "v1 × v2 = %s", cross_v1_v2_str);
+	wlf_log(WLF_INFO, "unit_x × unit_y = %s (should be unit_z)", cross_xy_str);
+	wlf_log(WLF_INFO, "unit_y × unit_z = %s (should be unit_x)", cross_yz_str);
+	wlf_log(WLF_INFO, "unit_z × unit_x = %s (should be unit_y)", cross_zx_str);
+
+	free(cross_v1_v2_str); free(cross_xy_str); free(cross_yz_str); free(cross_zx_str);
+
+	// Test Cross Product Properties
+	wlf_log(WLF_INFO, "\n--- Testing Cross Product Properties ---");
+
+	// Cross product is orthogonal to both vectors
+	double dot_cross_v1 = wlf_vector3_dot(&cross_v1_v2, &v1);
+	double dot_cross_v2 = wlf_vector3_dot(&cross_v1_v2, &v2);
+	wlf_log(WLF_INFO, "(v1 × v2) · v1 = %.6f (should be 0.000000)", dot_cross_v1);
+	wlf_log(WLF_INFO, "(v1 × v2) · v2 = %.6f (should be 0.000000)", dot_cross_v2);
+
+	// Anti-commutativity: a × b = -(b × a)
+	struct wlf_vector3 cross_v2_v1 = wlf_vector3_cross(&v2, &v1);
+	struct wlf_vector3 neg_cross_v2_v1 = wlf_vector3_multiply(&cross_v2_v1, -1.0);
+	bool anticommutative = wlf_vector3_nearly_equal(&cross_v1_v2, &neg_cross_v2_v1, 1e-10);
+	wlf_log(WLF_INFO, "Cross product anti-commutative: %s", anticommutative ? "true" : "false");
+
+	// Cross product with self is zero
+	struct wlf_vector3 cross_self = wlf_vector3_cross(&v1, &v1);
+	bool self_cross_zero = wlf_vector3_nearly_equal(&cross_self, &WLF_VECTOR3_ZERO, 1e-10);
+	wlf_log(WLF_INFO, "v1 × v1 = zero: %s", self_cross_zero ? "true" : "false");
+
+	// Test Normalization
+	wlf_log(WLF_INFO, "\n--- Testing Normalization ---");
+
+	struct wlf_vector3 v1_normalized = wlf_vector3_normalize(&v1);
+	struct wlf_vector3 v2_normalized = wlf_vector3_normalize(&v2);
+	struct wlf_vector3 zero_normalized = wlf_vector3_normalize(&WLF_VECTOR3_ZERO);
+
+	char *v1_norm_str = wlf_vector3_to_str(&v1_normalized);
+	char *v2_norm_str = wlf_vector3_to_str(&v2_normalized);
+	char *zero_norm_str = wlf_vector3_to_str(&zero_normalized);
+
+	wlf_log(WLF_INFO, "v1 normalized: %s", v1_norm_str);
+	wlf_log(WLF_INFO, "v2 normalized: %s", v2_norm_str);
+	wlf_log(WLF_INFO, "zero normalized: %s", zero_norm_str);
+
+	// Check normalized vector magnitudes
+	double v1_norm_mag = wlf_vector3_magnitude(&v1_normalized);
+	double v2_norm_mag = wlf_vector3_magnitude(&v2_normalized);
+	wlf_log(WLF_INFO, "v1_normalized magnitude: %.6f (should be 1.000000)", v1_norm_mag);
+	wlf_log(WLF_INFO, "v2_normalized magnitude: %.6f (should be 1.000000)", v2_norm_mag);
+
+	free(v1_norm_str); free(v2_norm_str); free(zero_norm_str);
+
+	// Test Mathematical Properties
+	wlf_log(WLF_INFO, "\n--- Testing Mathematical Properties ---");
+
+	// Test orthogonal vectors (90° angle)
+	struct wlf_vector3 ortho1 = wlf_vector3_make(1.0, 0.0, 0.0);
+	struct wlf_vector3 ortho2 = wlf_vector3_make(0.0, 1.0, 0.0);
+	double ortho_dot = wlf_vector3_dot(&ortho1, &ortho2);
+	wlf_log(WLF_INFO, "Orthogonal vectors dot product: %.3f (should be 0.000)", ortho_dot);
+
+	// Test parallel vectors
+	struct wlf_vector3 parallel1 = wlf_vector3_make(2.0, 3.0, 4.0);
+	struct wlf_vector3 parallel2 = wlf_vector3_make(4.0, 6.0, 8.0);
+	double parallel_dot = wlf_vector3_dot(&parallel1, &parallel2);
+	double parallel1_mag = wlf_vector3_magnitude(&parallel1);
+	double parallel2_mag = wlf_vector3_magnitude(&parallel2);
+	double expected_parallel_dot = parallel1_mag * parallel2_mag;
+	wlf_log(WLF_INFO, "Parallel vectors dot product: %.3f", parallel_dot);
+	wlf_log(WLF_INFO, "Expected (|v1| * |v2|): %.3f", expected_parallel_dot);
+
+	// Test anti-parallel vectors (180° angle)
+	struct wlf_vector3 anti1 = wlf_vector3_make(1.0, 2.0, 3.0);
+	struct wlf_vector3 anti2 = wlf_vector3_make(-2.0, -4.0, -6.0);
+	double anti_dot = wlf_vector3_dot(&anti1, &anti2);
+	double anti1_mag = wlf_vector3_magnitude(&anti1);
+	double anti2_mag = wlf_vector3_magnitude(&anti2);
+	double expected_anti_dot = -anti1_mag * anti2_mag;
+	wlf_log(WLF_INFO, "Anti-parallel vectors dot product: %.3f", anti_dot);
+	wlf_log(WLF_INFO, "Expected (-|v1| * |v2|): %.3f", expected_anti_dot);
+
+	// Test Edge Cases
+	wlf_log(WLF_INFO, "\n--- Testing Edge Cases ---");
+
+	// Division by zero
+	struct wlf_vector3 div_by_zero = wlf_vector3_divide(&v1, 0.0);
+	char *div_zero_str = wlf_vector3_to_str(&div_by_zero);
+	wlf_log(WLF_INFO, "v1 / 0.0 = %s (should equal v1)", div_zero_str);
+	free(div_zero_str);
+
+	// Very small numbers
+	struct wlf_vector3 tiny = wlf_vector3_make(1e-10, 1e-10, 1e-10);
+	double tiny_mag = wlf_vector3_magnitude(&tiny);
+	struct wlf_vector3 tiny_norm = wlf_vector3_normalize(&tiny);
+	char *tiny_str = wlf_vector3_to_str(&tiny);
+	char *tiny_norm_str = wlf_vector3_to_str(&tiny_norm);
+	wlf_log(WLF_INFO, "Tiny vector: %s", tiny_str);
+	wlf_log(WLF_INFO, "Tiny magnitude: %.12e", tiny_mag);
+	wlf_log(WLF_INFO, "Tiny normalized: %s", tiny_norm_str);
+	free(tiny_str); free(tiny_norm_str);
+
+	// Very large numbers
+	struct wlf_vector3 large = wlf_vector3_make(1e6, 1e6, 1e6);
+	double large_mag = wlf_vector3_magnitude(&large);
+	struct wlf_vector3 large_norm = wlf_vector3_normalize(&large);
+	char *large_str = wlf_vector3_to_str(&large);
+	char *large_norm_str = wlf_vector3_to_str(&large_norm);
+	wlf_log(WLF_INFO, "Large vector: %s", large_str);
+	wlf_log(WLF_INFO, "Large magnitude: %.3e", large_mag);
+	wlf_log(WLF_INFO, "Large normalized: %s", large_norm_str);
+	free(large_str); free(large_norm_str);
+
+	// Test Epsilon Comparison
+	wlf_log(WLF_INFO, "\n--- Testing Epsilon Comparison ---");
+
+	struct wlf_vector3 base = wlf_vector3_make(1.0, 2.0, 3.0);
+	struct wlf_vector3 tiny_diff = wlf_vector3_make(1.0000001, 2.0000001, 3.0000001);
+	struct wlf_vector3 big_diff = wlf_vector3_make(1.1, 2.1, 3.1);
+
+	double epsilons[] = {1e-10, 1e-6, 1e-3, 0.01, 0.1, 1.0};
+
+	for (int i = 0; i < 6; i++) {
+		double eps = epsilons[i];
+		bool tiny_equal = wlf_vector3_nearly_equal(&base, &tiny_diff, eps);
+		bool big_equal = wlf_vector3_nearly_equal(&base, &big_diff, eps);
+		wlf_log(WLF_INFO, "ε=%.0e: tiny_diff=%s, big_diff=%s", eps,
+				tiny_equal ? "true" : "false", big_equal ? "true" : "false");
+	}
+
+	// Test Vector Algebra Properties
+	wlf_log(WLF_INFO, "\n--- Testing Vector Algebra Properties ---");
+
+	// Commutativity: a + b = b + a
+	struct wlf_vector3 comm1 = wlf_vector3_add(&v1, &v2);
+	struct wlf_vector3 comm2 = wlf_vector3_add(&v2, &v1);
+	bool commutative = wlf_vector3_equal(&comm1, &comm2);
+	wlf_log(WLF_INFO, "Addition commutative: %s", commutative ? "true" : "false");
+
+	// Associativity: (a + b) + c = a + (b + c)
+	struct wlf_vector3 v3 = wlf_vector3_make(1.0, -1.0, 2.0);
+	struct wlf_vector3 assoc1_temp = wlf_vector3_add(&v1, &v2);
+	struct wlf_vector3 assoc1 = wlf_vector3_add(&assoc1_temp, &v3);
+	struct wlf_vector3 assoc2_temp = wlf_vector3_add(&v2, &v3);
+	struct wlf_vector3 assoc2 = wlf_vector3_add(&v1, &assoc2_temp);
+	bool associative = wlf_vector3_nearly_equal(&assoc1, &assoc2, 1e-10);
+	wlf_log(WLF_INFO, "Addition associative: %s", associative ? "true" : "false");
+
+	// Identity: v + 0 = v
+	struct wlf_vector3 identity = wlf_vector3_add(&v1, &WLF_VECTOR3_ZERO);
+	bool identity_prop = wlf_vector3_equal(&v1, &identity);
+	wlf_log(WLF_INFO, "Zero identity: %s", identity_prop ? "true" : "false");
+
+	// Scalar multiplication distributivity: k(a + b) = ka + kb
+	double k = 3.5;
+	struct wlf_vector3 dist1_temp = wlf_vector3_add(&v1, &v2);
+	struct wlf_vector3 dist1 = wlf_vector3_multiply(&dist1_temp, k);
+	struct wlf_vector3 dist2_temp1 = wlf_vector3_multiply(&v1, k);
+	struct wlf_vector3 dist2_temp2 = wlf_vector3_multiply(&v2, k);
+	struct wlf_vector3 dist2 = wlf_vector3_add(&dist2_temp1, &dist2_temp2);
+	bool distributive = wlf_vector3_nearly_equal(&dist1, &dist2, 1e-10);
+	wlf_log(WLF_INFO, "Scalar multiplication distributive: %s", distributive ? "true" : "false");
+
+	// Test Known Vector Calculations
+	wlf_log(WLF_INFO, "\n--- Testing Known Vector Calculations ---");
+
+	// 3-4-5-? Pythagorean-like calculation
+	struct wlf_vector3 vec_345 = wlf_vector3_make(3.0, 4.0, 0.0);
+	double mag_345 = wlf_vector3_magnitude(&vec_345);
+	wlf_log(WLF_INFO, "Vector(3,4,0) magnitude: %.3f (expected: 5.000)", mag_345);
+
+	// Unit cube diagonal
+	struct wlf_vector3 unit_cube_diag = wlf_vector3_make(1.0, 1.0, 1.0);
+	double unit_cube_mag = wlf_vector3_magnitude(&unit_cube_diag);
+	wlf_log(WLF_INFO, "Unit cube diagonal magnitude: %.6f (expected: %.6f)", unit_cube_mag, sqrt(3.0));
+
+	// Right-hand rule test: i × j = k
+	bool right_hand_rule = wlf_vector3_equal(&cross_unit_x_unit_y, &WLF_VECTOR3_UNIT_Z);
+	wlf_log(WLF_INFO, "Right-hand rule (i × j = k): %s", right_hand_rule ? "true" : "false");
+
+	// Test scalar triple product: a · (b × c)
+	struct wlf_vector3 a = wlf_vector3_make(1.0, 2.0, 3.0);
+	struct wlf_vector3 b = wlf_vector3_make(4.0, 5.0, 6.0);
+	struct wlf_vector3 c = wlf_vector3_make(7.0, 8.0, 9.0);
+	struct wlf_vector3 b_cross_c = wlf_vector3_cross(&b, &c);
+	double scalar_triple = wlf_vector3_dot(&a, &b_cross_c);
+	wlf_log(WLF_INFO, "Scalar triple product a·(b×c): %.3f", scalar_triple);
+
+	// For vectors (1,2,3), (4,5,6), (7,8,9), the scalar triple product should be 0
+	// because these vectors are coplanar (linearly dependent)
+	wlf_log(WLF_INFO, "Coplanar vectors scalar triple product should be 0.000");
+
+	wlf_log(WLF_INFO, "\n=== Vector3 Test Suite Complete ===");
+
+	return 0;
+}

--- a/examples/math/wlf_vector4_test.c
+++ b/examples/math/wlf_vector4_test.c
@@ -1,0 +1,331 @@
+#include "wlf/math/wlf_vector4.h"
+#include "wlf/utils/wlf_log.h"
+
+#include <stdlib.h>
+#include <stdint.h>
+#include <math.h>
+
+int main(int argc, char *argv[]) {
+	wlf_log_init(WLF_DEBUG, NULL);
+
+	wlf_log(WLF_INFO, "=== WLF Vector4 Test Suite ===");
+
+	// Test Vector4 Creation
+	wlf_log(WLF_INFO, "\n--- Testing Vector4 Creation ---");
+
+	struct wlf_vector4 v1 = wlf_vector4_make(3.0, 4.0, 5.0, 6.0);
+	struct wlf_vector4 v2 = wlf_vector4_make(-2.5, 1.5, -3.0, 2.0);
+	struct wlf_vector4 zero_vec = WLF_VECTOR4_ZERO;
+	struct wlf_vector4 unit_x = WLF_VECTOR4_UNIT_X;
+	struct wlf_vector4 unit_y = WLF_VECTOR4_UNIT_Y;
+	struct wlf_vector4 unit_z = WLF_VECTOR4_UNIT_Z;
+	struct wlf_vector4 unit_w = WLF_VECTOR4_UNIT_W;
+
+	char *str1 = wlf_vector4_to_str(&v1);
+	char *str2 = wlf_vector4_to_str(&v2);
+	char *str_zero = wlf_vector4_to_str(&zero_vec);
+	char *str_unit_x = wlf_vector4_to_str(&unit_x);
+	char *str_unit_y = wlf_vector4_to_str(&unit_y);
+	char *str_unit_z = wlf_vector4_to_str(&unit_z);
+	char *str_unit_w = wlf_vector4_to_str(&unit_w);
+
+	wlf_log(WLF_INFO, "v1: %s", str1);
+	wlf_log(WLF_INFO, "v2: %s", str2);
+	wlf_log(WLF_INFO, "zero: %s", str_zero);
+	wlf_log(WLF_INFO, "unit_x: %s", str_unit_x);
+	wlf_log(WLF_INFO, "unit_y: %s", str_unit_y);
+	wlf_log(WLF_INFO, "unit_z: %s", str_unit_z);
+	wlf_log(WLF_INFO, "unit_w: %s", str_unit_w);
+
+	free(str1); free(str2); free(str_zero);
+	free(str_unit_x); free(str_unit_y); free(str_unit_z); free(str_unit_w);
+
+	// Test Constants
+	wlf_log(WLF_INFO, "\n--- Testing Constants ---");
+
+	char *zero_str = wlf_vector4_to_str(&WLF_VECTOR4_ZERO);
+	char *unit_x_str = wlf_vector4_to_str(&WLF_VECTOR4_UNIT_X);
+	char *unit_y_str = wlf_vector4_to_str(&WLF_VECTOR4_UNIT_Y);
+	char *unit_z_str = wlf_vector4_to_str(&WLF_VECTOR4_UNIT_Z);
+	char *unit_w_str = wlf_vector4_to_str(&WLF_VECTOR4_UNIT_W);
+
+	wlf_log(WLF_INFO, "WLF_VECTOR4_ZERO: %s", zero_str);
+	wlf_log(WLF_INFO, "WLF_VECTOR4_UNIT_X: %s", unit_x_str);
+	wlf_log(WLF_INFO, "WLF_VECTOR4_UNIT_Y: %s", unit_y_str);
+	wlf_log(WLF_INFO, "WLF_VECTOR4_UNIT_Z: %s", unit_z_str);
+	wlf_log(WLF_INFO, "WLF_VECTOR4_UNIT_W: %s", unit_w_str);
+
+	free(zero_str); free(unit_x_str); free(unit_y_str); free(unit_z_str); free(unit_w_str);
+
+	// Test Equality
+	wlf_log(WLF_INFO, "\n--- Testing Equality ---");
+
+	struct wlf_vector4 v1_copy = wlf_vector4_make(3.0, 4.0, 5.0, 6.0);
+	struct wlf_vector4 v1_approx = wlf_vector4_make(3.00001, 4.00001, 5.00001, 6.00001);
+
+	wlf_log(WLF_INFO, "v1 == v1_copy (exact): %s", wlf_vector4_equal(&v1, &v1_copy) ? "true" : "false");
+	wlf_log(WLF_INFO, "v1 == v2 (exact): %s", wlf_vector4_equal(&v1, &v2) ? "true" : "false");
+	wlf_log(WLF_INFO, "v1 ≈ v1_approx (ε=0.001): %s", wlf_vector4_nearly_equal(&v1, &v1_approx, 0.001) ? "true" : "false");
+	wlf_log(WLF_INFO, "v1 ≈ v1_approx (ε=0.000001): %s", wlf_vector4_nearly_equal(&v1, &v1_approx, 0.000001) ? "true" : "false");
+
+	// Test Arithmetic Operations
+	wlf_log(WLF_INFO, "\n--- Testing Arithmetic Operations ---");
+
+	struct wlf_vector4 add_result = wlf_vector4_add(&v1, &v2);
+	struct wlf_vector4 sub_result = wlf_vector4_subtract(&v1, &v2);
+	struct wlf_vector4 mul_result = wlf_vector4_multiply(&v1, 2.5);
+	struct wlf_vector4 div_result = wlf_vector4_divide(&v1, 2.0);
+
+	char *add_str = wlf_vector4_to_str(&add_result);
+	char *sub_str = wlf_vector4_to_str(&sub_result);
+	char *mul_str = wlf_vector4_to_str(&mul_result);
+	char *div_str = wlf_vector4_to_str(&div_result);
+
+	wlf_log(WLF_INFO, "v1 + v2 = %s", add_str);
+	wlf_log(WLF_INFO, "v1 - v2 = %s", sub_str);
+	wlf_log(WLF_INFO, "v1 * 2.5 = %s", mul_str);
+	wlf_log(WLF_INFO, "v1 / 2.0 = %s", div_str);
+
+	free(add_str); free(sub_str); free(mul_str); free(div_str);
+
+	// Test Vector Properties
+	wlf_log(WLF_INFO, "\n--- Testing Vector Properties ---");
+
+	double v1_magnitude = wlf_vector4_magnitude(&v1);
+	double v2_magnitude = wlf_vector4_magnitude(&v2);
+	double zero_magnitude = wlf_vector4_magnitude(&WLF_VECTOR4_ZERO);
+	double unit_x_magnitude = wlf_vector4_magnitude(&WLF_VECTOR4_UNIT_X);
+
+	wlf_log(WLF_INFO, "v1 magnitude: %.3f (expected: 9.274)", v1_magnitude);
+	wlf_log(WLF_INFO, "v2 magnitude: %.3f", v2_magnitude);
+	wlf_log(WLF_INFO, "zero magnitude: %.3f", zero_magnitude);
+	wlf_log(WLF_INFO, "unit_x magnitude: %.3f (expected: 1.000)", unit_x_magnitude);
+
+	// Test Dot Product
+	wlf_log(WLF_INFO, "\n--- Testing Dot Product ---");
+
+	double dot_v1_v2 = wlf_vector4_dot(&v1, &v2);
+	double dot_v1_unit_x = wlf_vector4_dot(&v1, &WLF_VECTOR4_UNIT_X);
+	double dot_v1_unit_y = wlf_vector4_dot(&v1, &WLF_VECTOR4_UNIT_Y);
+	double dot_v1_unit_z = wlf_vector4_dot(&v1, &WLF_VECTOR4_UNIT_Z);
+	double dot_v1_unit_w = wlf_vector4_dot(&v1, &WLF_VECTOR4_UNIT_W);
+	double dot_v1_self = wlf_vector4_dot(&v1, &v1);
+
+	wlf_log(WLF_INFO, "v1 · v2 = %.3f", dot_v1_v2);
+	wlf_log(WLF_INFO, "v1 · unit_x = %.3f (should equal v1.x = 3.000)", dot_v1_unit_x);
+	wlf_log(WLF_INFO, "v1 · unit_y = %.3f (should equal v1.y = 4.000)", dot_v1_unit_y);
+	wlf_log(WLF_INFO, "v1 · unit_z = %.3f (should equal v1.z = 5.000)", dot_v1_unit_z);
+	wlf_log(WLF_INFO, "v1 · unit_w = %.3f (should equal v1.w = 6.000)", dot_v1_unit_w);
+	wlf_log(WLF_INFO, "v1 · v1 = %.3f (should equal |v1|² = 86.000)", dot_v1_self);
+
+	// Test Normalization
+	wlf_log(WLF_INFO, "\n--- Testing Normalization ---");
+
+	struct wlf_vector4 v1_normalized = wlf_vector4_normalize(&v1);
+	struct wlf_vector4 v2_normalized = wlf_vector4_normalize(&v2);
+	struct wlf_vector4 zero_normalized = wlf_vector4_normalize(&WLF_VECTOR4_ZERO);
+
+	char *v1_norm_str = wlf_vector4_to_str(&v1_normalized);
+	char *v2_norm_str = wlf_vector4_to_str(&v2_normalized);
+	char *zero_norm_str = wlf_vector4_to_str(&zero_normalized);
+
+	wlf_log(WLF_INFO, "v1 normalized: %s", v1_norm_str);
+	wlf_log(WLF_INFO, "v2 normalized: %s", v2_norm_str);
+	wlf_log(WLF_INFO, "zero normalized: %s", zero_norm_str);
+
+	// Check normalized vector magnitudes
+	double v1_norm_mag = wlf_vector4_magnitude(&v1_normalized);
+	double v2_norm_mag = wlf_vector4_magnitude(&v2_normalized);
+	wlf_log(WLF_INFO, "v1_normalized magnitude: %.6f (should be 1.000000)", v1_norm_mag);
+	wlf_log(WLF_INFO, "v2_normalized magnitude: %.6f (should be 1.000000)", v2_norm_mag);
+
+	free(v1_norm_str); free(v2_norm_str); free(zero_norm_str);
+
+	// Test Mathematical Properties
+	wlf_log(WLF_INFO, "\n--- Testing Mathematical Properties ---");
+
+	// Test orthogonal vectors (90° angle)
+	struct wlf_vector4 ortho1 = wlf_vector4_make(1.0, 0.0, 0.0, 0.0);
+	struct wlf_vector4 ortho2 = wlf_vector4_make(0.0, 1.0, 0.0, 0.0);
+	double ortho_dot = wlf_vector4_dot(&ortho1, &ortho2);
+	wlf_log(WLF_INFO, "Orthogonal vectors dot product: %.3f (should be 0.000)", ortho_dot);
+
+	// Test parallel vectors
+	struct wlf_vector4 parallel1 = wlf_vector4_make(2.0, 3.0, 4.0, 5.0);
+	struct wlf_vector4 parallel2 = wlf_vector4_make(4.0, 6.0, 8.0, 10.0);
+	double parallel_dot = wlf_vector4_dot(&parallel1, &parallel2);
+	double parallel1_mag = wlf_vector4_magnitude(&parallel1);
+	double parallel2_mag = wlf_vector4_magnitude(&parallel2);
+	double expected_parallel_dot = parallel1_mag * parallel2_mag;
+	wlf_log(WLF_INFO, "Parallel vectors dot product: %.3f", parallel_dot);
+	wlf_log(WLF_INFO, "Expected (|v1| * |v2|): %.3f", expected_parallel_dot);
+
+	// Test anti-parallel vectors (180° angle)
+	struct wlf_vector4 anti1 = wlf_vector4_make(1.0, 2.0, 3.0, 4.0);
+	struct wlf_vector4 anti2 = wlf_vector4_make(-2.0, -4.0, -6.0, -8.0);
+	double anti_dot = wlf_vector4_dot(&anti1, &anti2);
+	double anti1_mag = wlf_vector4_magnitude(&anti1);
+	double anti2_mag = wlf_vector4_magnitude(&anti2);
+	double expected_anti_dot = -anti1_mag * anti2_mag;
+	wlf_log(WLF_INFO, "Anti-parallel vectors dot product: %.3f", anti_dot);
+	wlf_log(WLF_INFO, "Expected (-|v1| * |v2|): %.3f", expected_anti_dot);
+
+	// Test Edge Cases
+	wlf_log(WLF_INFO, "\n--- Testing Edge Cases ---");
+
+	// Division by zero
+	struct wlf_vector4 div_by_zero = wlf_vector4_divide(&v1, 0.0);
+	char *div_zero_str = wlf_vector4_to_str(&div_by_zero);
+	wlf_log(WLF_INFO, "v1 / 0.0 = %s (should equal v1)", div_zero_str);
+	free(div_zero_str);
+
+	// Very small numbers
+	struct wlf_vector4 tiny = wlf_vector4_make(1e-10, 1e-10, 1e-10, 1e-10);
+	double tiny_mag = wlf_vector4_magnitude(&tiny);
+	struct wlf_vector4 tiny_norm = wlf_vector4_normalize(&tiny);
+	char *tiny_str = wlf_vector4_to_str(&tiny);
+	char *tiny_norm_str = wlf_vector4_to_str(&tiny_norm);
+	wlf_log(WLF_INFO, "Tiny vector: %s", tiny_str);
+	wlf_log(WLF_INFO, "Tiny magnitude: %.12e", tiny_mag);
+	wlf_log(WLF_INFO, "Tiny normalized: %s", tiny_norm_str);
+	free(tiny_str); free(tiny_norm_str);
+
+	// Very large numbers
+	struct wlf_vector4 large = wlf_vector4_make(1e6, 1e6, 1e6, 1e6);
+	double large_mag = wlf_vector4_magnitude(&large);
+	struct wlf_vector4 large_norm = wlf_vector4_normalize(&large);
+	char *large_str = wlf_vector4_to_str(&large);
+	char *large_norm_str = wlf_vector4_to_str(&large_norm);
+	wlf_log(WLF_INFO, "Large vector: %s", large_str);
+	wlf_log(WLF_INFO, "Large magnitude: %.3e", large_mag);
+	wlf_log(WLF_INFO, "Large normalized: %s", large_norm_str);
+	free(large_str); free(large_norm_str);
+
+	// Test Epsilon Comparison
+	wlf_log(WLF_INFO, "\n--- Testing Epsilon Comparison ---");
+
+	struct wlf_vector4 base = wlf_vector4_make(1.0, 2.0, 3.0, 4.0);
+	struct wlf_vector4 tiny_diff = wlf_vector4_make(1.0000001, 2.0000001, 3.0000001, 4.0000001);
+	struct wlf_vector4 big_diff = wlf_vector4_make(1.1, 2.1, 3.1, 4.1);
+
+	double epsilons[] = {1e-10, 1e-6, 1e-3, 0.01, 0.1, 1.0};
+
+	for (int i = 0; i < 6; i++) {
+		double eps = epsilons[i];
+		bool tiny_equal = wlf_vector4_nearly_equal(&base, &tiny_diff, eps);
+		bool big_equal = wlf_vector4_nearly_equal(&base, &big_diff, eps);
+		wlf_log(WLF_INFO, "ε=%.0e: tiny_diff=%s, big_diff=%s", eps,
+				tiny_equal ? "true" : "false", big_equal ? "true" : "false");
+	}
+
+	// Test Vector Algebra Properties
+	wlf_log(WLF_INFO, "\n--- Testing Vector Algebra Properties ---");
+
+	// Commutativity: a + b = b + a
+	struct wlf_vector4 comm1 = wlf_vector4_add(&v1, &v2);
+	struct wlf_vector4 comm2 = wlf_vector4_add(&v2, &v1);
+	bool commutative = wlf_vector4_equal(&comm1, &comm2);
+	wlf_log(WLF_INFO, "Addition commutative: %s", commutative ? "true" : "false");
+
+	// Associativity: (a + b) + c = a + (b + c)
+	struct wlf_vector4 v3 = wlf_vector4_make(1.0, -1.0, 2.0, -2.0);
+	struct wlf_vector4 assoc1_temp = wlf_vector4_add(&v1, &v2);
+	struct wlf_vector4 assoc1 = wlf_vector4_add(&assoc1_temp, &v3);
+	struct wlf_vector4 assoc2_temp = wlf_vector4_add(&v2, &v3);
+	struct wlf_vector4 assoc2 = wlf_vector4_add(&v1, &assoc2_temp);
+	bool associative = wlf_vector4_nearly_equal(&assoc1, &assoc2, 1e-10);
+	wlf_log(WLF_INFO, "Addition associative: %s", associative ? "true" : "false");
+
+	// Identity: v + 0 = v
+	struct wlf_vector4 identity = wlf_vector4_add(&v1, &WLF_VECTOR4_ZERO);
+	bool identity_prop = wlf_vector4_equal(&v1, &identity);
+	wlf_log(WLF_INFO, "Zero identity: %s", identity_prop ? "true" : "false");
+
+	// Scalar multiplication distributivity: k(a + b) = ka + kb
+	double k = 3.5;
+	struct wlf_vector4 dist1_temp = wlf_vector4_add(&v1, &v2);
+	struct wlf_vector4 dist1 = wlf_vector4_multiply(&dist1_temp, k);
+	struct wlf_vector4 dist2_temp1 = wlf_vector4_multiply(&v1, k);
+	struct wlf_vector4 dist2_temp2 = wlf_vector4_multiply(&v2, k);
+	struct wlf_vector4 dist2 = wlf_vector4_add(&dist2_temp1, &dist2_temp2);
+	bool distributive = wlf_vector4_nearly_equal(&dist1, &dist2, 1e-10);
+	wlf_log(WLF_INFO, "Scalar multiplication distributive: %s", distributive ? "true" : "false");
+
+	// Test Known Vector Calculations
+	wlf_log(WLF_INFO, "\n--- Testing Known Vector Calculations ---");
+
+	// Unit hypercube diagonal (1,1,1,1)
+	struct wlf_vector4 unit_hypercube_diag = wlf_vector4_make(1.0, 1.0, 1.0, 1.0);
+	double unit_hypercube_mag = wlf_vector4_magnitude(&unit_hypercube_diag);
+	wlf_log(WLF_INFO, "Unit hypercube diagonal magnitude: %.6f (expected: %.6f)", unit_hypercube_mag, sqrt(4.0));
+
+	// Test all unit vectors orthogonality
+	wlf_log(WLF_INFO, "\n--- Testing Unit Vector Orthogonality ---");
+
+	double dot_x_y = wlf_vector4_dot(&WLF_VECTOR4_UNIT_X, &WLF_VECTOR4_UNIT_Y);
+	double dot_x_z = wlf_vector4_dot(&WLF_VECTOR4_UNIT_X, &WLF_VECTOR4_UNIT_Z);
+	double dot_x_w = wlf_vector4_dot(&WLF_VECTOR4_UNIT_X, &WLF_VECTOR4_UNIT_W);
+	double dot_y_z = wlf_vector4_dot(&WLF_VECTOR4_UNIT_Y, &WLF_VECTOR4_UNIT_Z);
+	double dot_y_w = wlf_vector4_dot(&WLF_VECTOR4_UNIT_Y, &WLF_VECTOR4_UNIT_W);
+	double dot_z_w = wlf_vector4_dot(&WLF_VECTOR4_UNIT_Z, &WLF_VECTOR4_UNIT_W);
+
+	wlf_log(WLF_INFO, "unit_x · unit_y = %.3f (should be 0.000)", dot_x_y);
+	wlf_log(WLF_INFO, "unit_x · unit_z = %.3f (should be 0.000)", dot_x_z);
+	wlf_log(WLF_INFO, "unit_x · unit_w = %.3f (should be 0.000)", dot_x_w);
+	wlf_log(WLF_INFO, "unit_y · unit_z = %.3f (should be 0.000)", dot_y_z);
+	wlf_log(WLF_INFO, "unit_y · unit_w = %.3f (should be 0.000)", dot_y_w);
+	wlf_log(WLF_INFO, "unit_z · unit_w = %.3f (should be 0.000)", dot_z_w);
+
+	// Test homogeneous coordinates (commonly used in 3D graphics)
+	wlf_log(WLF_INFO, "\n--- Testing Homogeneous Coordinates ---");
+
+	// Point in 3D space represented as 4D homogeneous coordinates (x, y, z, 1)
+	struct wlf_vector4 point_3d = wlf_vector4_make(3.0, 4.0, 5.0, 1.0);
+	// Vector in 3D space represented as 4D homogeneous coordinates (x, y, z, 0)
+	struct wlf_vector4 vector_3d = wlf_vector4_make(1.0, 1.0, 1.0, 0.0);
+
+	char *point_str = wlf_vector4_to_str(&point_3d);
+	char *vector_str = wlf_vector4_to_str(&vector_3d);
+	wlf_log(WLF_INFO, "3D point as homogeneous: %s", point_str);
+	wlf_log(WLF_INFO, "3D vector as homogeneous: %s", vector_str);
+	free(point_str); free(vector_str);
+
+	// Test quaternion-like operations (though this is not a true quaternion)
+	wlf_log(WLF_INFO, "\n--- Testing Quaternion-like Vector ---");
+
+	// A quaternion-like vector (not actual quaternion math, just testing 4D properties)
+	struct wlf_vector4 quat_like = wlf_vector4_make(0.5, 0.5, 0.5, 0.5);
+	double quat_mag = wlf_vector4_magnitude(&quat_like);
+	struct wlf_vector4 quat_normalized = wlf_vector4_normalize(&quat_like);
+
+	char *quat_str = wlf_vector4_to_str(&quat_like);
+	char *quat_norm_str = wlf_vector4_to_str(&quat_normalized);
+	wlf_log(WLF_INFO, "Quaternion-like vector: %s", quat_str);
+	wlf_log(WLF_INFO, "Magnitude: %.6f (expected: 1.000000)", quat_mag);
+	wlf_log(WLF_INFO, "Normalized: %s", quat_norm_str);
+	free(quat_str); free(quat_norm_str);
+
+	// Test color vector (RGBA)
+	wlf_log(WLF_INFO, "\n--- Testing Color Vector (RGBA) ---");
+
+	struct wlf_vector4 color_red = wlf_vector4_make(1.0, 0.0, 0.0, 1.0);
+	struct wlf_vector4 color_green = wlf_vector4_make(0.0, 1.0, 0.0, 0.5);
+	struct wlf_vector4 color_blend = wlf_vector4_add(&color_red, &color_green);
+	struct wlf_vector4 color_average = wlf_vector4_divide(&color_blend, 2.0);
+
+	char *red_str = wlf_vector4_to_str(&color_red);
+	char *green_str = wlf_vector4_to_str(&color_green);
+	char *blend_str = wlf_vector4_to_str(&color_blend);
+	char *avg_str = wlf_vector4_to_str(&color_average);
+
+	wlf_log(WLF_INFO, "Red color (RGBA): %s", red_str);
+	wlf_log(WLF_INFO, "Green color (RGBA): %s", green_str);
+	wlf_log(WLF_INFO, "Color blend: %s", blend_str);
+	wlf_log(WLF_INFO, "Color average: %s", avg_str);
+
+	free(red_str); free(green_str); free(blend_str); free(avg_str);
+
+	wlf_log(WLF_INFO, "\n=== Vector4 Test Suite Complete ===");
+
+	return 0;
+}

--- a/examples/meson.build
+++ b/examples/meson.build
@@ -4,3 +4,4 @@ endif
 
 subdir('image')
 subdir('utils')
+subdir('math')

--- a/include/wlf/math/wlf_fpoint.h
+++ b/include/wlf/math/wlf_fpoint.h
@@ -1,0 +1,258 @@
+/**
+ * @file        wlf_fpoint.h
+ * @brief       2D floating-point point math utility for wlframe.
+ * @details     This file provides structures and functions for 2D floating-point point operations,
+ *              including creation, conversion, arithmetic, distance calculation, interpolation, rotation,
+ *              normalization, and geometric queries.
+ * @author      YaoBing Xiao
+ * @date        2024-05-20
+ * @version     v1.0
+ * @par Copyright(c):
+ * @par History:
+ *      version: v1.0, YaoBing Xiao, 2024-05-20, initial version\n
+ */
+
+#ifndef MATH_WLF_FPOINT_H
+#define MATH_WLF_FPOINT_H
+
+#include "wlf/math/wlf_point.h"
+
+#include <stdbool.h>
+#include <stdint.h>
+#include <math.h>
+
+/**
+ * @brief A structure representing a 2D floating-point point.
+ */
+struct wlf_fpoint {
+	double x;  /**< The x coordinate */
+	double y;  /**< The y coordinate */
+};
+
+/**
+ * @brief Common constant floating-point points.
+ */
+static const struct wlf_fpoint WLF_FPOINT_ZERO = {0.0, 0.0};    /**< Origin point (0.0,0.0) */
+static const struct wlf_fpoint WLF_FPOINT_UNIT = {1.0, 1.0};    /**< Unit point (1.0,1.0) */
+static const struct wlf_fpoint WLF_FPOINT_UNIT_X = {1.0, 0.0};  /**< Unit vector in x direction */
+static const struct wlf_fpoint WLF_FPOINT_UNIT_Y = {0.0, 1.0};  /**< Unit vector in y direction */
+
+/**
+ * @brief Converts a 2D floating-point point to a string representation. 3 decimal places.
+ * @param point Source floating-point point.
+ * @return A string representing the floating-point point.
+ */
+char *wlf_fpoint_to_str(const struct wlf_fpoint *point);
+
+/**
+ * @brief Converts a 2D floating-point point to a string representation.
+ * @param point Source floating-point point.
+ * @param precision Number of decimal places (0-15).
+ * @return A string representing the floating-point point.
+ */
+char *wlf_fpoint_to_str_prec(const struct wlf_fpoint *point, uint8_t precision);
+
+/**
+ * @brief Checks if two floating-point points are equal.
+ * @param a First point.
+ * @param b Second point.
+ * @return true if points are equal, false otherwise.
+ */
+bool wlf_fpoint_equal(const struct wlf_fpoint *a, const struct wlf_fpoint *b);
+
+/**
+ * @brief Checks if two floating-point points are nearly equal within epsilon.
+ * @param a First point.
+ * @param b Second point.
+ * @param epsilon Maximum allowed difference.
+ * @return true if points are nearly equal, false otherwise.
+ */
+bool wlf_fpoint_nearly_equal(const struct wlf_fpoint *a, const struct wlf_fpoint *b, double epsilon);
+
+/**
+ * @brief Checks if a floating-point point is zero (origin).
+ * @param p Point to check.
+ * @return true if point is zero, false otherwise.
+ */
+bool wlf_fpoint_is_zero(const struct wlf_fpoint *p);
+
+/**
+ * @brief Adds two floating-point points.
+ * @param a First point.
+ * @param b Second point.
+ * @return Result of a + b.
+ */
+struct wlf_fpoint wlf_fpoint_add(const struct wlf_fpoint *a, const struct wlf_fpoint *b);
+
+/**
+ * @brief Subtracts two floating-point points.
+ * @param a First point.
+ * @param b Second point.
+ * @return Result of a - b.
+ */
+struct wlf_fpoint wlf_fpoint_subtract(const struct wlf_fpoint *a, const struct wlf_fpoint *b);
+
+/**
+ * @brief Multiplies a floating-point point by a scalar.
+ * @param p Point to multiply.
+ * @param scalar Scalar value.
+ * @return Result of p * scalar.
+ */
+struct wlf_fpoint wlf_fpoint_multiply(const struct wlf_fpoint *p, double scalar);
+
+/**
+ * @brief Divides a floating-point point by a scalar.
+ * @param p Point to divide.
+ * @param scalar Scalar value. Must not be zero.
+ * @return Result of p / scalar.
+ */
+struct wlf_fpoint wlf_fpoint_divide(const struct wlf_fpoint *p, double scalar);
+
+/**
+ * @brief Negates a floating-point point.
+ * @param p Point to negate.
+ * @return Negated point (-x, -y).
+ */
+struct wlf_fpoint wlf_fpoint_negate(const struct wlf_fpoint *p);
+
+/**
+ * @brief Calculates Manhattan distance between two floating-point points.
+ * @param p1 First point.
+ * @param p2 Second point.
+ * @return Manhattan distance |x1-x2| + |y1-y2|.
+ */
+double wlf_fpoint_manhattan_distance(const struct wlf_fpoint *p1, const struct wlf_fpoint *p2);
+
+/**
+ * @brief Calculates Euclidean distance between two floating-point points.
+ * @param p1 First point.
+ * @param p2 Second point.
+ * @return Euclidean distance sqrt((x1-x2)² + (y1-y2)²).
+ */
+double wlf_fpoint_euclidean_distance(const struct wlf_fpoint *p1, const struct wlf_fpoint *p2);
+
+/**
+ * @brief Calculates dot product of two floating-point points.
+ * @param a First point.
+ * @param b Second point.
+ * @return Dot product (a.x * b.x + a.y * b.y).
+ */
+double wlf_fpoint_dot_product(const struct wlf_fpoint *a, const struct wlf_fpoint *b);
+
+/**
+ * @brief Calculates the angle of a point relative to positive x-axis.
+ * @param p Point to calculate angle for.
+ * @return Angle in radians.
+ */
+double wlf_fpoint_angle(const struct wlf_fpoint *p);
+
+/**
+ * @brief Calculates the angle between two points.
+ * @param a First point.
+ * @param b Second point.
+ * @return Angle in radians.
+ */
+double wlf_fpoint_angle_between(const struct wlf_fpoint *a, const struct wlf_fpoint *b);
+
+/**
+ * @brief Rotates a point by given angle.
+ * @param p Point to rotate.
+ * @param angle_radians Angle in radians.
+ * @return Rotated point.
+ */
+struct wlf_fpoint wlf_fpoint_rotate(const struct wlf_fpoint *p, double angle_radians);
+
+/**
+ * @brief Gets the length (magnitude) of a point vector.
+ * @param p Point to get length of.
+ * @return Length of the point vector.
+ */
+double wlf_fpoint_length(const struct wlf_fpoint *p);
+
+/**
+ * @brief Gets the squared length of a point vector.
+ * @param p Point to get squared length of.
+ * @return Squared length of the point vector.
+ */
+double wlf_fpoint_length_squared(const struct wlf_fpoint *p);
+
+/**
+ * @brief Checks if point is inside a circle.
+ * @param p Point to check.
+ * @param center Circle center.
+ * @param radius Circle radius.
+ * @return true if point is inside circle, false otherwise.
+ */
+bool wlf_fpoint_in_circle(const struct wlf_fpoint *p, const struct wlf_fpoint *center, double radius);
+
+/**
+ * @brief Rounds floating-point coordinates to nearest integers.
+ * @param p Point to round.
+ * @return Rounded integer point.
+ */
+struct wlf_point wlf_fpoint_round(const struct wlf_fpoint *p);
+
+/**
+ * @brief Floors floating-point coordinates to integers.
+ * @param p Point to floor.
+ * @return Floored integer point.
+ */
+struct wlf_point wlf_fpoint_floor(const struct wlf_fpoint *p);
+
+/**
+ * @brief Ceils floating-point coordinates to integers.
+ * @param p Point to ceil.
+ * @return Ceiled integer point.
+ */
+struct wlf_point wlf_fpoint_ceil(const struct wlf_fpoint *p);
+
+/**
+ * @brief Normalizes a floating-point point (makes it unit length).
+ * @param p Point to normalize.
+ * @return Normalized point.
+ */
+struct wlf_fpoint wlf_fpoint_normalize(const struct wlf_fpoint *p);
+
+/**
+ * @brief Performs linear interpolation between two points.
+ * @param a Start point.
+ * @param b End point.
+ * @param t Interpolation parameter (0.0 to 1.0).
+ * @return Interpolated point.
+ */
+struct wlf_fpoint wlf_fpoint_lerp(const struct wlf_fpoint *a, const struct wlf_fpoint *b, double t);
+
+/**
+ * @brief Calculates quadratic Bezier curve point.
+ * @param p0 Start point.
+ * @param p1 Control point.
+ * @param p2 End point.
+ * @param t Curve parameter (0.0 to 1.0).
+ * @return Point on Bezier curve.
+ */
+struct wlf_fpoint wlf_fpoint_bezier(const struct wlf_fpoint *p0, const struct wlf_fpoint *p1,
+	const struct wlf_fpoint *p2, double t);
+
+/**
+ * @brief Converts integer point to floating-point point.
+ * @param p Integer point to convert.
+ * @return Equivalent floating-point point.
+ */
+struct wlf_fpoint wlf_point_to_fpoint(const struct wlf_point *p);
+
+/**
+ * @brief Converts floating-point point to integer point (truncates).
+ * @param p Floating-point point to convert.
+ * @return Equivalent integer point.
+ */
+struct wlf_point wlf_fpoint_to_point(const struct wlf_fpoint *p);
+
+/**
+ * @brief Converts a string representation of a point to a wlf_fpoint structure.
+ * @param str String in the format "(x, y)".
+ * @param point Pointer to the wlf_fpoint structure to fill.
+ * @return true if conversion was successful, false otherwise.
+ */
+bool wlf_fpoint_from_str(const char *str, struct wlf_fpoint *point);
+
+#endif // MATH_WLF_FPOINT_H

--- a/include/wlf/math/wlf_frect.h
+++ b/include/wlf/math/wlf_frect.h
@@ -1,0 +1,140 @@
+/**
+ * @file        wlf_frect.h
+ * @brief       2D floating-point rectangle math utility for wlframe.
+ * @details     This file provides structures and functions for 2D floating-point rectangle operations,
+ *              including creation, conversion, arithmetic, geometric queries, intersection, union, and rounding.
+ * @author      YaoBing Xiao
+ * @date        2024-05-20
+ * @version     v1.0
+ * @par Copyright(c):
+ * @par History:
+ *      version: v1.0, YaoBing Xiao, 2024-05-20, initial version\n
+ */
+
+#ifndef MATH_WLF_FRECT_H
+#define MATH_WLF_FRECT_H
+
+#include "wlf/math/wlf_fpoint.h"
+#include "wlf/math/wlf_fsize.h"
+#include "wlf/math/wlf_rect.h"
+
+#include <stdbool.h>
+#include <stdint.h>
+
+/**
+ * @brief A structure representing a 2D floating-point rectangle.
+ */
+struct wlf_frect {
+	double x;      /**< X coordinate of the top-left corner */
+	double y;      /**< Y coordinate of the top-left corner */
+	double width;  /**< Width of the rectangle */
+	double height; /**< Height of the rectangle */
+};
+
+static const struct wlf_frect WLF_FRECT_ZERO = {0.0, 0.0, 0.0, 0.0};  /**< Zero rectangle */
+static const struct wlf_frect WLF_FRECT_UNIT = {0.0, 0.0, 1.0, 1.0};  /**< Unit rectangle */
+
+/**
+ * @brief Creates a new floating-point rectangle from position and size.
+ * @param x X coordinate of the top-left corner.
+ * @param y Y coordinate of the top-left corner.
+ * @param width Width of the rectangle.
+ * @param height Height of the rectangle.
+ * @return A new wlf_frect structure.
+ */
+struct wlf_frect wlf_frect_make(double x, double y, double width, double height);
+
+/**
+ * @brief Creates a rectangle from point and size.
+ * @param pos Top-left position.
+ * @param size Rectangle size.
+ * @return A new wlf_rect structure.
+ */
+struct wlf_frect wlf_frect_from_point_size(const struct wlf_fpoint *pos, const struct wlf_fsize *size);
+
+/**
+ * @brief Creates a rectangle from two points.
+ * @param p1 First point (top-left).
+ * @param p2 Second point (bottom-right).
+ * @return A new wlf_rect structure.
+ */
+struct wlf_frect wlf_frect_from_points(const struct wlf_fpoint *p1, const struct wlf_fpoint *p2);
+
+/**
+ * @brief Converts a floating-point rectangle to a string representation with specified precision.
+ * @param rect Source floating-point rectangle.
+ * @param precision Number of decimal places (0-15).
+ * @return A string representing the floating-point rectangle, or NULL if memory allocation fails.
+ */
+char* wlf_frect_to_str_prec(const struct wlf_frect *rect, uint8_t precision);
+
+/**
+ * @brief Checks if two floating-point rectangles are exactly equal.
+ * @param a First floating-point rectangle.
+ * @param b Second floating-point rectangle.
+ * @return true if rectangles are exactly equal (all components match), false otherwise.
+ */
+bool wlf_frect_equal(const struct wlf_frect *a, const struct wlf_frect *b);
+
+/**
+ * @brief Checks if two floating-point rectangles are approximately equal within an epsilon.
+ * @param a First floating-point rectangle.
+ * @param b Second floating-point rectangle.
+ * @param epsilon Maximum allowed difference between corresponding components.
+ * @return true if the absolute difference between all corresponding components is less than epsilon,
+ *         false otherwise.
+ */
+bool wlf_frect_nearly_equal(const struct wlf_frect *a, const struct wlf_frect *b, double epsilon);
+
+/**
+ * @brief Converts integer rectangle to floating-point rectangle.
+ * @param rect Integer rectangle to convert.
+ * @return Equivalent floating-point rectangle.
+ */
+struct wlf_frect wlf_rect_to_frect(const struct wlf_rect *rect);
+
+/**
+ * @brief Converts floating-point rectangle to integer rectangle.
+ * @param rect Floating-point rectangle to convert.
+ * @return Equivalent integer rectangle.
+ */
+struct wlf_rect wlf_frect_to_rect(const struct wlf_frect *rect);
+
+/**
+ * @brief Rounds floating-point rectangle to nearest integers.
+ * @param rect Rectangle to round.
+ * @return Rounded integer rectangle.
+ */
+struct wlf_rect wlf_frect_round(const struct wlf_frect *rect);
+
+/**
+ * @brief Floors floating-point rectangle to integers.
+ * @param rect Rectangle to floor.
+ * @return Floored integer rectangle.
+ */
+struct wlf_rect wlf_frect_floor(const struct wlf_frect *rect);
+
+/**
+ * @brief Ceils floating-point rectangle to integers.
+ * @param rect Rectangle to ceil.
+ * @return Ceiled integer rectangle.
+ */
+struct wlf_rect wlf_frect_ceil(const struct wlf_frect *rect);
+
+/**
+ * @brief Checks if floating-point rectangle is valid (positive width and height).
+ * @param rect Rectangle to check.
+ * @return true if rectangle is valid (width > 0 and height > 0), false otherwise.
+ */
+bool wlf_frect_is_valid(const struct wlf_frect *rect);
+
+/**
+ * @brief Parses a string representation of a floating-point rectangle and creates a wlf_frect structure.
+ * @param str String representation of rectangle in format "(x,y,width,height)"
+ *            or "(x, y, width, height)".
+ * @param rect Pointer to the rectangle structure to fill.
+ * @return true if parsing was successful, false otherwise.
+ */
+bool wlf_frect_from_str(const char *str, struct wlf_frect *rect);
+
+#endif // MATH_WLF_FRECT_H

--- a/include/wlf/math/wlf_fsize.h
+++ b/include/wlf/math/wlf_fsize.h
@@ -1,0 +1,162 @@
+/**
+ * @file        wlf_fsize.h
+ * @brief       2D floating-point size math utility for wlframe.
+ * @details     This file provides structures and functions for 2D floating-point size operations,
+ *              including creation, conversion, arithmetic, comparison, and rounding.
+ * @author      YaoBing Xiao
+ * @date        2024-05-20
+ * @version     v1.0
+ * @par Copyright(c):
+ * @par History:
+ *      version: v1.0, YaoBing Xiao, 2024-05-20, initial version\n
+ */
+
+#ifndef MATH_WLF_FSIZE_H
+#define MATH_WLF_FSIZE_H
+
+#include "wlf/math/wlf_size.h"
+
+#include <stdbool.h>
+#include <stdint.h>
+
+/**
+ * @brief A structure representing a 2D floating-point size.
+ */
+struct wlf_fsize {
+	double width;   /**< The width value */
+	double height;  /**< The height value */
+};
+
+static const struct wlf_fsize WLF_FSIZE_ZERO = {0.0, 0.0};  /**< Zero size (0.0,0.0) */
+static const struct wlf_fsize WLF_FSIZE_UNIT = {1.0, 1.0};  /**< Unit size (1.0,1.0) */
+
+/**
+ * @brief Converts a 2D floating-point size to a string representation. 3 decimal places.
+ * @param size Source floating-point size.
+ * @return A string representing the floating-point size.
+ */
+char *wlf_fsize_to_str(const struct wlf_fsize *size);
+
+/**
+ * @brief Converts a floating-point size to a string representation with specified precision.
+ * @param size Source floating-point size.
+ * @param precision Number of decimal places (0-15).
+ * @return A string representing the floating-point size, or NULL if memory allocation fails.
+ */
+char *wlf_fsize_to_str_prec(const struct wlf_fsize *size, uint8_t precision);
+
+/**
+ * @brief Checks if two floating-point sizes are equal.
+ * @param a First size.
+ * @param b Second size.
+ * @return true if sizes are equal, false otherwise.
+ */
+bool wlf_fsize_equal(const struct wlf_fsize *a, const struct wlf_fsize *b);
+
+/**
+ * @brief Checks if two floating-point sizes are nearly equal within epsilon.
+ * @param a First size.
+ * @param b Second size.
+ * @param epsilon Maximum allowed difference.
+ * @return true if sizes are nearly equal, false otherwise.
+ */
+bool wlf_fsize_nearly_equal(const struct wlf_fsize *a, const struct wlf_fsize *b, double epsilon);
+
+/**
+ * @brief Adds two floating-point sizes together.
+ * @param a First floating-point size operand.
+ * @param b Second floating-point size operand.
+ * @return A new wlf_fsize structure where:
+ *         - width = a->width + b->width
+ *         - height = a->height + b->height
+ */
+struct wlf_fsize wlf_fsize_add(const struct wlf_fsize *a, const struct wlf_fsize *b);
+
+/**
+ * @brief Subtracts the second floating-point size from the first.
+ * @param a First floating-point size (minuend).
+ * @param b Second floating-point size (subtrahend).
+ * @return A new wlf_fsize structure where:
+ *         - width = a->width - b->width
+ *         - height = a->height - b->height
+ */
+struct wlf_fsize wlf_fsize_subtract(const struct wlf_fsize *a, const struct wlf_fsize *b);
+
+/**
+ * @brief Multiplies a floating-point size by a scalar value.
+ * @param size The floating-point size to be multiplied.
+ * @param scalar The scalar value to multiply by.
+ * @return A new wlf_fsize structure where:
+ *         - width = size->width * scalar
+ *         - height = size->height * scalar
+ */
+struct wlf_fsize wlf_fsize_multiply(const struct wlf_fsize *size, double scalar);
+
+/**
+ * @brief Divides a floating-point size by a scalar value.
+ * @param size The floating-point size to be divided.
+ * @param scalar The scalar value to divide by (must not be zero).
+ * @return A new wlf_fsize structure where:
+ *         - width = size->width / scalar
+ *         - height = size->height / scalar
+ */
+struct wlf_fsize wlf_fsize_divide(const struct wlf_fsize *size, double scalar);
+
+/**
+ * @brief Calculates the area of the floating-point size.
+ * @param size Size to calculate area for.
+ * @return Area (width * height).
+ */
+double wlf_fsize_area(const struct wlf_fsize *size);
+
+/**
+ * @brief Converts integer size to floating-point size.
+ * @param size Integer size to convert.
+ * @return Equivalent floating-point size.
+ */
+struct wlf_fsize wlf_size_to_fsize(const struct wlf_size *size);
+
+/**
+ * @brief Converts floating-point size to integer size.
+ * @param size Floating-point size to convert.
+ * @return Equivalent integer size.
+ */
+struct wlf_size wlf_fsize_to_size(const struct wlf_fsize *size);
+
+/**
+ * @brief Rounds floating-point size to nearest integers.
+ * @param size Size to round.
+ * @return Rounded integer size.
+ */
+struct wlf_size wlf_fsize_round(const struct wlf_fsize *size);
+
+/**
+ * @brief Floors floating-point size to integers.
+ * @param size Size to floor.
+ * @return Floored integer size.
+ */
+struct wlf_size wlf_fsize_floor(const struct wlf_fsize *size);
+
+/**
+ * @brief Ceils floating-point size to integers.
+ * @param size Size to ceil.
+ * @return Ceiled integer size.
+ */
+struct wlf_size wlf_fsize_ceil(const struct wlf_fsize *size);
+
+/**
+ * @brief Converts a string representation of a point to a wlf_fsize structure.
+ * @param str String in the format "(width, height)".
+ * @param point Pointer to the wlf_fsize structure to fill.
+ * @return true if conversion was successful, false otherwise.
+ */
+bool wlf_fsize_from_str(const char *str, struct wlf_fsize *size);
+
+/**
+ * @brief Checks if a floating-point size is valid.
+ * @param size Size to validate.
+ * @return true if size is valid (width > 0 and height > 0), false otherwise.
+ */
+bool wlf_fsize_is_valid(const struct wlf_fsize *size);
+
+#endif // MATH_WLF_FSIZE_H

--- a/include/wlf/math/wlf_matrix3x3.h
+++ b/include/wlf/math/wlf_matrix3x3.h
@@ -1,0 +1,134 @@
+/**
+ * @file        wlf_matrix3x3.h
+ * @brief       3x3 matrix math utility for wlframe.
+ * @details     This file provides a structure and functions for 3x3 matrix operations,
+ *              including creation, conversion, arithmetic, transpose, determinant,
+ *              inversion, and comparison.
+ * @author      YaoBing Xiao
+ * @date        2024-05-20
+ * @version     v1.0
+ * @par Copyright(c):
+ * @par History:
+ *      version: v1.0, YaoBing Xiao, 2024-05-20, initial version\n
+ */
+
+#ifndef MATH_WLF_MATRIX3X3_H
+#define MATH_WLF_MATRIX3X3_H
+
+#include <stdbool.h>
+
+/**
+ * @brief A structure representing a 3x3 matrix.
+ */
+struct wlf_matrix3x3 {
+	double elements[3][3];  /**< 3x3 array of matrix elements */
+};
+
+/**
+ * @brief Creates a new 3x3 matrix initialized to zero.
+ * @return A new wlf_matrix3x3 structure.
+ */
+struct wlf_matrix3x3 wlf_matrix3x3_create_zero(void);
+
+/**
+ * @brief Creates a new 3x3 identity matrix.
+ * @return A new identity matrix.
+ */
+struct wlf_matrix3x3 wlf_matrix3x3_identity(void);
+
+/**
+ * @brief Converts a 3x3 matrix to a string representation.
+ * @param matrix Source matrix.
+ * @return A string representing the matrix.
+ */
+char* wlf_matrix3x3_to_str(const struct wlf_matrix3x3 *matrix);
+
+/**
+ * @brief Gets an element from the 3x3 matrix.
+ * @param matrix Source matrix.
+ * @param row Row index (0-based).
+ * @param col Column index (0-based).
+ * @return Value at the specified position.
+ */
+double wlf_matrix3x3_get(const struct wlf_matrix3x3 *matrix, int row, int col);
+
+/**
+ * @brief Sets an element in the 3x3 matrix.
+ * @param matrix Target matrix.
+ * @param row Row index (0-based).
+ * @param col Column index (0-based).
+ * @param value Value to set.
+ */
+void wlf_matrix3x3_set(struct wlf_matrix3x3 *matrix, int row, int col, double value);
+
+/**
+ * @brief Adds two 3x3 matrices.
+ * @param a First matrix.
+ * @param b Second matrix.
+ * @return Result of a + b.
+ */
+struct wlf_matrix3x3 wlf_matrix3x3_add(const struct wlf_matrix3x3 *a, const struct wlf_matrix3x3 *b);
+
+/**
+ * @brief Subtracts two 3x3 matrices.
+ * @param a First matrix.
+ * @param b Second matrix.
+ * @return Result of a - b.
+ */
+struct wlf_matrix3x3 wlf_matrix3x3_subtract(const struct wlf_matrix3x3 *a, const struct wlf_matrix3x3 *b);
+
+/**
+ * @brief Multiplies a 3x3 matrix by a scalar.
+ * @param matrix Input matrix.
+ * @param scalar Scalar value.
+ * @return Scaled matrix.
+ */
+struct wlf_matrix3x3 wlf_matrix3x3_multiply_scalar(const struct wlf_matrix3x3 *matrix, double scalar);
+
+/**
+ * @brief Multiplies two 3x3 matrices.
+ * @param a First matrix.
+ * @param b Second matrix.
+ * @return Result of a × b.
+ */
+struct wlf_matrix3x3 wlf_matrix3x3_multiply(const struct wlf_matrix3x3 *a, const struct wlf_matrix3x3 *b);
+
+/**
+ * @brief Transposes a 3x3 matrix.
+ * @param matrix Input matrix.
+ * @return Transposed matrix.
+ */
+struct wlf_matrix3x3 wlf_matrix3x3_transpose(const struct wlf_matrix3x3 *matrix);
+
+/**
+ * @brief Calculates the determinant of a 3x3 matrix.
+ * @param matrix Input matrix.
+ * @return Determinant value.
+ */
+double wlf_matrix3x3_determinant(const struct wlf_matrix3x3 *matrix);
+
+/**
+ * @brief Inverts a 3x3 matrix.
+ * @param matrix Input matrix (must be invertible).
+ * @return Inverted matrix.
+ */
+struct wlf_matrix3x3 wlf_matrix3x3_inverse(const struct wlf_matrix3x3 *matrix);
+
+/**
+ * @brief Checks if two 3x3 matrices are equal.
+ * @param a First matrix.
+ * @param b Second matrix.
+ * @return true if matrices are equal, false otherwise.
+ */
+bool wlf_matrix3x3_equal(const struct wlf_matrix3x3 *a, const struct wlf_matrix3x3 *b);
+
+/**
+ * @brief Checks if two 3x3 matrices are nearly equal within epsilon.
+ * @param a First matrix.
+ * @param b Second matrix.
+ * @param epsilon Maximum allowed difference.
+ * @return true if matrices are nearly equal, false otherwise.
+ */
+bool wlf_matrix3x3_nearly_equal(const struct wlf_matrix3x3 *a, const struct wlf_matrix3x3 *b, double epsilon);
+
+#endif // MATH_WLF_MATRIX3X3_H

--- a/include/wlf/math/wlf_matrix4x4.h
+++ b/include/wlf/math/wlf_matrix4x4.h
@@ -1,0 +1,134 @@
+/**
+ * @file        wlf_matrix4x4.h
+ * @brief       4x4 matrix math utility for wlframe.
+ * @details     This file provides a structure and functions for 4x4 matrix operations,
+ *              including creation, conversion, arithmetic, transpose, determinant,
+ *              inversion, and comparison.
+ * @author      YaoBing Xiao
+ * @date        2024-05-20
+ * @version     v1.0
+ * @par Copyright(c):
+ * @par History:
+ *      version: v1.0, YaoBing Xiao, 2024-05-20, initial version\n
+ */
+
+#ifndef MATH_WLF_MATRIX4X4_H
+#define MATH_WLF_MATRIX4X4_H
+
+#include <stdbool.h>
+
+/**
+ * @brief A structure representing a 4x4 matrix.
+ */
+struct wlf_matrix4x4 {
+	double elements[4][4];  /**< 4x4 array of matrix elements */
+};
+
+/**
+ * @brief Creates a new 4x4 matrix initialized to zero.
+ * @return A new wlf_matrix4x4 structure.
+ */
+struct wlf_matrix4x4 wlf_matrix4x4_create_zero(void);
+
+/**
+ * @brief Creates a new 4x4 identity matrix.
+ * @return A new identity matrix.
+ */
+struct wlf_matrix4x4 wlf_matrix4x4_identity(void);
+
+/**
+ * @brief Converts a 4x4 matrix to a string representation.
+ * @param matrix Source matrix.
+ * @return A string representing the matrix.
+ */
+char* wlf_matrix4x4_to_str(const struct wlf_matrix4x4 *matrix);
+
+/**
+ * @brief Gets an element from the 4x4 matrix.
+ * @param matrix Source matrix.
+ * @param row Row index (0-based).
+ * @param col Column index (0-based).
+ * @return Value at the specified position.
+ */
+double wlf_matrix4x4_get(const struct wlf_matrix4x4 *matrix, int row, int col);
+
+/**
+ * @brief Sets an element in the 4x4 matrix.
+ * @param matrix Target matrix.
+ * @param row Row index (0-based).
+ * @param col Column index (0-based).
+ * @param value Value to set.
+ */
+void wlf_matrix4x4_set(struct wlf_matrix4x4 *matrix, int row, int col, double value);
+
+/**
+ * @brief Adds two 4x4 matrices.
+ * @param a First matrix.
+ * @param b Second matrix.
+ * @return Result of a + b.
+ */
+struct wlf_matrix4x4 wlf_matrix4x4_add(const struct wlf_matrix4x4 *a, const struct wlf_matrix4x4 *b);
+
+/**
+ * @brief Subtracts two 4x4 matrices.
+ * @param a First matrix.
+ * @param b Second matrix.
+ * @return Result of a - b.
+ */
+struct wlf_matrix4x4 wlf_matrix4x4_subtract(const struct wlf_matrix4x4 *a, const struct wlf_matrix4x4 *b);
+
+/**
+ * @brief Multiplies a 4x4 matrix by a scalar.
+ * @param matrix Input matrix.
+ * @param scalar Scalar value.
+ * @return Scaled matrix.
+ */
+struct wlf_matrix4x4 wlf_matrix4x4_multiply_scalar(const struct wlf_matrix4x4 *matrix, double scalar);
+
+/**
+ * @brief Multiplies two 4x4 matrices.
+ * @param a First matrix.
+ * @param b Second matrix.
+ * @return Result of a × b.
+ */
+struct wlf_matrix4x4 wlf_matrix4x4_multiply(const struct wlf_matrix4x4 *a, const struct wlf_matrix4x4 *b);
+
+/**
+ * @brief Transposes a 4x4 matrix.
+ * @param matrix Input matrix.
+ * @return Transposed matrix.
+ */
+struct wlf_matrix4x4 wlf_matrix4x4_transpose(const struct wlf_matrix4x4 *matrix);
+
+/**
+ * @brief Calculates the determinant of a 4x4 matrix.
+ * @param matrix Input matrix.
+ * @return Determinant value.
+ */
+double wlf_matrix4x4_determinant(const struct wlf_matrix4x4 *matrix);
+
+/**
+ * @brief Inverts a 4x4 matrix.
+ * @param matrix Input matrix (must be invertible).
+ * @return Inverted matrix.
+ */
+struct wlf_matrix4x4 wlf_matrix4x4_inverse(const struct wlf_matrix4x4 *matrix);
+
+/**
+ * @brief Checks if two 4x4 matrices are equal.
+ * @param a First matrix.
+ * @param b Second matrix.
+ * @return true if matrices are equal, false otherwise.
+ */
+bool wlf_matrix4x4_equal(const struct wlf_matrix4x4 *a, const struct wlf_matrix4x4 *b);
+
+/**
+ * @brief Checks if two 4x4 matrices are nearly equal within epsilon.
+ * @param a First matrix.
+ * @param b Second matrix.
+ * @param epsilon Maximum allowed difference.
+ * @return true if matrices are nearly equal, false otherwise.
+ */
+bool wlf_matrix4x4_nearly_equal(const struct wlf_matrix4x4 *a, const struct wlf_matrix4x4 *b, double epsilon);
+
+#endif // MATH_WLF_MATRIX4X4_H

--- a/include/wlf/math/wlf_point.h
+++ b/include/wlf/math/wlf_point.h
@@ -1,0 +1,106 @@
+/**
+ * @file        wlf_point.h
+ * @brief       2D integer point math utility for wlframe.
+ * @details     This file provides structures and functions for 2D integer point operations,
+ *              including creation, conversion, arithmetic, and distance calculation.
+ * @author      YaoBing Xiao
+ * @date        2024-05-20
+ * @version     v1.0
+ * @par Copyright(c):
+ * @par History:
+ *      version: v1.0, YaoBing Xiao, 2024-05-20, initial version\n
+ */
+
+#ifndef MATH_WLF_POINT_H
+#define MATH_WLF_POINT_H
+
+#include <stdbool.h>
+#include <math.h>
+
+/**
+ * @brief A structure representing a 2D integer point.
+ */
+struct wlf_point {
+	int x;  /**< The x coordinate */
+	int y;  /**< The y coordinate */
+};
+
+/**
+ * @brief Common constant points.
+ */
+static const struct wlf_point WLF_POINT_ZERO = {0, 0};        /**< Origin point (0,0) */
+static const struct wlf_point WLF_POINT_UNIT = {1, 1};        /**< Unit point (1,1) */
+static const struct wlf_point WLF_POINT_UNIT_X = {1, 0};      /**< Unit vector in x direction */
+static const struct wlf_point WLF_POINT_UNIT_Y = {0, 1};      /**< Unit vector in y direction */
+
+/**
+ * @brief Converts a 2D integer point to a string representation.
+ * @param point Source point.
+ * @return A string representing the point.
+ */
+char *wlf_point_to_str(const struct wlf_point *point);
+
+/**
+ * @brief Checks if two integer points are equal.
+ * @param a First point.
+ * @param b Second point.
+ * @return true if points are equal, false otherwise.
+ */
+bool wlf_point_equal(const struct wlf_point *a, const struct wlf_point *b);
+
+/**
+ * @brief Checks if an integer point is zero (origin).
+ * @param p Point to check.
+ * @return true if point is zero, false otherwise.
+ */
+bool wlf_point_is_zero(const struct wlf_point *p);
+
+/**
+ * @brief Adds two integer points.
+ * @param a First point.
+ * @param b Second point.
+ * @return Result of a + b.
+ */
+struct wlf_point wlf_point_add(const struct wlf_point *a, const struct wlf_point *b);
+
+/**
+ * @brief Subtracts two integer points.
+ * @param a First point.
+ * @param b Second point.
+ * @return Result of a - b.
+ */
+struct wlf_point wlf_point_subtract(const struct wlf_point *a, const struct wlf_point *b);
+
+/**
+ * @brief Multiplies an integer point by a scalar.
+ * @param p Point to multiply.
+ * @param scalar Scalar value.
+ * @return Result of p * scalar.
+ */
+struct wlf_point wlf_point_multiply(const struct wlf_point *p, double scalar);
+
+/**
+ * @brief Calculates Manhattan distance between two points.
+ * @param p1 First point.
+ * @param p2 Second point.
+ * @return Manhattan distance |x1-x2| + |y1-y2|.
+ */
+int wlf_point_manhattan_distance(const struct wlf_point *p1, const struct wlf_point *p2);
+
+/**
+ * @brief Calculates Euclidean distance between two points.
+ * @param p1 First point.
+ * @param p2 Second point.
+ * @return Euclidean distance sqrt((x1-x2)² + (y1-y2)²).
+ */
+double wlf_point_euclidean_distance(const struct wlf_point *p1, const struct wlf_point *p2);
+
+/**
+ * @brief Converts a string representation of a point to a wlf_point structure.
+ * @param str String in the format "(x, y)".
+ * @param point Pointer to the wlf_point structure to fill.
+ * @return true if conversion was successful, false otherwise.
+ */
+bool wlf_point_from_str(const char *str, struct wlf_point *point);
+
+#endif // MATH_WLF_POINT_H

--- a/include/wlf/math/wlf_quaternion.h
+++ b/include/wlf/math/wlf_quaternion.h
@@ -1,0 +1,122 @@
+/**
+ * @file        wlf_quaternion.h
+ * @brief       Quaternion math utility for wlframe.
+ * @details     This file provides a structure and functions for quaternion operations,
+ *              including creation, conversion, arithmetic, normalization, conjugation,
+ *              inversion, norm calculation, and comparison.
+ * @author      YaoBing Xiao
+ * @date        2024-05-20
+ * @version     v1.0
+ * @par Copyright(c):
+ * @par History:
+ *      version: v1.0, YaoBing Xiao, 2024-05-20, initial version\n
+ */
+
+#ifndef MATH_WLF_QUATERNION_H
+#define MATH_WLF_QUATERNION_H
+
+#include <stdbool.h>
+#include <stdint.h>
+
+/**
+ * @brief A structure representing a quaternion.
+ */
+struct wlf_quaternion {
+	double w;  /**< The scalar part */
+	double x;  /**< The x component */
+	double y;  /**< The y component */
+	double z;  /**< The z component */
+};
+
+static const struct wlf_quaternion WLF_QUATERNION_IDENTITY = {1.0, 0.0, 0.0, 0.0}; /**< Identity quaternion (1,0,0,0) */
+
+/**
+ * @brief Creates a new quaternion from w, x, y, and z components.
+ * @param w The scalar part.
+ * @param x The x component.
+ * @param y The y component.
+ * @param z The z component.
+ * @return A new wlf_quaternion structure.
+ */
+struct wlf_quaternion wlf_quaternion_make(double w, double x, double y, double z);
+
+/**
+ * @brief Converts a quaternion to a string representation.
+ * @param quaternion Source quaternion.
+ * @return A string representing the quaternion, Quaternion(w, x, y, z).
+ */
+char* wlf_quaternion_to_str(const struct wlf_quaternion *quaternion);
+
+
+char* wlf_quaternion_to_str_prec(const struct wlf_quaternion *quaternion, uint8_t precision);
+
+/**
+ * @brief Adds two quaternions.
+ * @param a First quaternion.
+ * @param b Second quaternion.
+ * @return Result of a + b.
+ */
+struct wlf_quaternion wlf_quaternion_add(const struct wlf_quaternion *a, const struct wlf_quaternion *b);
+
+/**
+ * @brief Subtracts two quaternions.
+ * @param a First quaternion.
+ * @param b Second quaternion.
+ * @return Result of a - b.
+ */
+struct wlf_quaternion wlf_quaternion_subtract(const struct wlf_quaternion *a, const struct wlf_quaternion *b);
+
+/**
+ * @brief Multiplies two quaternions.
+ * @param a First quaternion.
+ * @param b Second quaternion.
+ * @return Result of a * b.
+ */
+struct wlf_quaternion wlf_quaternion_multiply(const struct wlf_quaternion *a, const struct wlf_quaternion *b);
+
+/**
+ * @brief Conjugates a quaternion.
+ * @param q Input quaternion.
+ * @return Conjugated quaternion.
+ */
+struct wlf_quaternion wlf_quaternion_conjugate(const struct wlf_quaternion *q);
+
+/**
+ * @brief Calculates the norm (magnitude) of a quaternion.
+ * @param q Input quaternion.
+ * @return Norm of the quaternion.
+ */
+double wlf_quaternion_norm(const struct wlf_quaternion *q);
+
+/**
+ * @brief Normalizes a quaternion to unit length.
+ * @param q Input quaternion.
+ * @return Normalized quaternion.
+ */
+struct wlf_quaternion wlf_quaternion_normalize(const struct wlf_quaternion *q);
+
+/**
+ * @brief Calculates the inverse of a quaternion.
+ * @param q Input quaternion (must be non-zero).
+ * @return Inverted quaternion.
+ */
+struct wlf_quaternion wlf_quaternion_inverse(const struct wlf_quaternion *q);
+
+/**
+ * @brief Checks if two quaternions are equal.
+ * @param a First quaternion.
+ * @param b Second quaternion.
+ * @return true if quaternions are equal, false otherwise.
+ */
+bool wlf_quaternion_equal(const struct wlf_quaternion *a, const struct wlf_quaternion *b);
+
+/**
+ * @brief Checks if two quaternions are nearly equal within epsilon.
+ * @param a First quaternion.
+ * @param b Second quaternion.
+ * @param epsilon Maximum allowed difference.
+ * @return true if quaternions are nearly equal, false otherwise.
+ */
+bool wlf_quaternion_nearly_equal(const struct wlf_quaternion *a, const struct wlf_quaternion *b, double epsilon);
+
+#endif // MATH_WLF_QUATERNION_H

--- a/include/wlf/math/wlf_ray2.h
+++ b/include/wlf/math/wlf_ray2.h
@@ -1,0 +1,71 @@
+/**
+ * @file        wlf_ray2.h
+ * @brief       2D ray math utility for wlframe.
+ * @details     This file provides a structure and functions for 2D ray operations,
+ *              including creation, conversion, point calculation, and comparison.
+ * @author      YaoBing Xiao
+ * @date        2025-06-22
+ * @version     v1.0
+ * @par Copyright(c):
+ * @par History:
+ *      version: v1.0, YaoBing Xiao, 2025-06-22, initial version\n
+ */
+
+#ifndef MATH_WLF_RAY2_H
+#define MATH_WLF_RAY2_H
+
+#include "wlf/math/wlf_vector2.h"
+
+#include <stdbool.h>
+
+/**
+ * @brief A structure representing a 2D ray.
+ */
+struct wlf_ray2 {
+	struct wlf_vector2 origin;    /**< The origin point of the ray */
+	struct wlf_vector2 direction; /**< The direction vector of the ray */
+};
+
+static const struct wlf_ray2 WLF_RAY2_ZERO = {{0.0, 0.0}, {0.0, 0.0}}; /**< Zero ray (origin at (0,0) with zero direction) */
+
+/**
+ * @brief Creates a new 2D ray from origin and direction.
+ * @param origin The origin point of the ray.
+ * @param direction The direction vector of the ray (must be normalized).
+ * @return A new wlf_ray2 structure.
+ */
+struct wlf_ray2 wlf_ray2_make(struct wlf_vector2 origin, struct wlf_vector2 direction);
+
+/**
+ * @brief Converts a ray to a string representation.
+ * @param ray Source ray.
+ * @return A string representing the ray.
+ */
+char* wlf_ray2_to_str(const struct wlf_ray2 *ray);
+
+/**
+ * @brief Computes a point along the ray at a given distance.
+ * @param ray The ray.
+ * @param t The distance along the ray.
+ * @return The point at distance t from the origin.
+ */
+struct wlf_vector2 wlf_ray2_point_at_parameter(const struct wlf_ray2 *ray, double t);
+
+/**
+ * @brief Checks if two rays are equal.
+ * @param a First ray.
+ * @param b Second ray.
+ * @return true if rays are equal, false otherwise.
+ */
+bool wlf_ray2_equal(const struct wlf_ray2 *a, const struct wlf_ray2 *b);
+
+/**
+ * @brief Checks if two rays are nearly equal within epsilon.
+ * @param a First ray.
+ * @param b Second ray.
+ * @param epsilon Maximum allowed difference.
+ * @return true if rays are nearly equal, false otherwise.
+ */
+bool wlf_ray2_nearly_equal(const struct wlf_ray2 *a, const struct wlf_ray2 *b, double epsilon);
+
+#endif // MATH_WLF_RAY2_H

--- a/include/wlf/math/wlf_ray3.h
+++ b/include/wlf/math/wlf_ray3.h
@@ -1,0 +1,71 @@
+/**
+ * @file        wlf_ray3.h
+ * @brief       3D ray math utility for wlframe.
+ * @details     This file provides a structure and functions for 3D ray operations,
+ *              including creation, conversion, point calculation, and comparison.
+ * @author      YaoBing Xiao
+ * @date        2024-05-20
+ * @version     v1.0
+ * @par Copyright(c):
+ * @par History:
+ *      version: v1.0, YaoBing Xiao, 2024-05-20, initial version\n
+ */
+
+#ifndef MATH_WLF_RAY3_H
+#define MATH_WLF_RAY3_H
+
+#include "wlf/math/wlf_vector3.h"
+
+#include <stdbool.h>
+
+/**
+ * @brief A structure representing a 3D ray.
+ */
+struct wlf_ray3 {
+	struct wlf_vector3 origin;    /**< The origin point of the ray */
+	struct wlf_vector3 direction; /**< The direction vector of the ray */
+};
+
+static const struct wlf_ray3 WLF_RAY_ZERO = {{0.0, 0.0, 0.0}, {0.0, 0.0, 0.0}}; /**< Zero ray (origin at (0,0,0) with zero direction) */
+
+/**
+ * @brief Creates a new 3D ray from origin and direction.
+ * @param origin The origin point of the ray.
+ * @param direction The direction vector of the ray (must be normalized).
+ * @return A new wlf_ray3 structure.
+ */
+struct wlf_ray3 wlf_ray3_make(struct wlf_vector3 origin, struct wlf_vector3 direction);
+
+/**
+ * @brief Converts a ray to a string representation.
+ * @param ray Source ray.
+ * @return A string representing the ray.
+ */
+char* wlf_ray3_to_str(const struct wlf_ray3 *ray);
+
+/**
+ * @brief Computes a point along the ray at a given distance.
+ * @param ray The ray.
+ * @param t The distance along the ray.
+ * @return The point at distance t from the origin.
+ */
+struct wlf_vector3 wlf_ray3_point_at_parameter(const struct wlf_ray3 *ray, double t);
+
+/**
+ * @brief Checks if two rays are equal.
+ * @param a First ray.
+ * @param b Second ray.
+ * @return true if rays are equal, false otherwise.
+ */
+bool wlf_ray3_equal(const struct wlf_ray3 *a, const struct wlf_ray3 *b);
+
+/**
+ * @brief Checks if two rays are nearly equal within epsilon.
+ * @param a First ray.
+ * @param b Second ray.
+ * @param epsilon Maximum allowed difference.
+ * @return true if rays are nearly equal, false otherwise.
+ */
+bool wlf_ray3_nearly_equal(const struct wlf_ray3 *a, const struct wlf_ray3 *b, double epsilon);
+
+#endif // MATH_WLF_RAY_H

--- a/include/wlf/math/wlf_rect.h
+++ b/include/wlf/math/wlf_rect.h
@@ -1,0 +1,222 @@
+/**
+ * @file        wlf_rect.h
+ * @brief       2D integer rectangle math utility for wlframe.
+ * @details     This file provides structures and functions for 2D integer rectangle operations,
+ *              including creation, conversion, arithmetic, geometric queries, intersection, and union.
+ * @author      YaoBing Xiao
+ * @date        2024-05-20
+ * @version     v1.0
+ * @par Copyright(c):
+ * @par History:
+ *      version: v1.0, YaoBing Xiao, 2024-05-20, initial version\n
+ */
+
+#ifndef MATH_WLF_RECT_H
+#define MATH_WLF_RECT_H
+
+#include "wlf/math/wlf_point.h"
+#include "wlf/math/wlf_size.h"
+#include <stdbool.h>
+
+/**
+ * @brief A structure representing a 2D integer rectangle.
+ */
+struct wlf_rect {
+	int x;      /**< X coordinate of the top-left corner */
+	int y;      /**< Y coordinate of the top-left corner */
+	int width;  /**< Width of the rectangle */
+	int height; /**< Height of the rectangle */
+};
+
+static const struct wlf_rect WLF_RECT_ZERO = {0, 0, 0, 0};            /**< Zero rectangle */
+static const struct wlf_rect WLF_RECT_UNIT = {0, 0, 1, 1};            /**< Unit rectangle */
+
+/**
+ * @brief Creates a new rectangle from position and size.
+ * @param x X coordinate.
+ * @param y Y coordinate.
+ * @param width Width value.
+ * @param height Height value.
+ * @return A new wlf_rect structure.
+ */
+struct wlf_rect wlf_rect_make(int x, int y, int width, int height);
+
+/**
+ * @brief Converts a rectangle to a string representation.
+ * @param rect Source rectangle.
+ * @return A string representing the rectangle, Rect(x, y, width, height).
+ */
+char* wlf_rect_to_str(const struct wlf_rect *rect);
+
+/**
+ * @brief Creates a rectangle from point and size.
+ * @param pos Top-left position.
+ * @param size Rectangle size.
+ * @return A new wlf_rect structure.
+ */
+struct wlf_rect wlf_rect_from_point_size(const struct wlf_point *pos, const struct wlf_size *size);
+
+/**
+ * @brief Creates a rectangle from two points.
+ * @param p1 First point (top-left).
+ * @param p2 Second point (bottom-right).
+ * @return A new wlf_rect structure.
+ */
+struct wlf_rect wlf_rect_from_points(const struct wlf_point *p1, const struct wlf_point *p2);
+
+/**
+ * @brief Checks if two rectangles are equal.
+ * @param a First rectangle.
+ * @param b Second rectangle.
+ * @return true if rectangles are equal, false otherwise.
+ */
+bool wlf_rect_equal(const struct wlf_rect *a, const struct wlf_rect *b);
+
+/**
+ * @brief Checks if rectangle is empty (zero width or height).
+ * @param rect Rectangle to check.
+ * @return true if rectangle is empty, false otherwise.
+ */
+bool wlf_rect_is_empty(const struct wlf_rect *rect);
+
+/**
+ * @brief Checks if rectangle is valid (positive width and height).
+ * @param rect Rectangle to check.
+ * @return true if rectangle is valid, false otherwise.
+ */
+bool wlf_rect_is_valid(const struct wlf_rect *rect);
+
+/**
+ * @brief Gets the position (top-left corner) of the rectangle.
+ * @param rect Source rectangle.
+ * @return Top-left point.
+ */
+struct wlf_point wlf_rect_get_position(const struct wlf_rect *rect);
+
+/**
+ * @brief Gets the size of the rectangle.
+ * @param rect Source rectangle.
+ * @return Rectangle size.
+ */
+struct wlf_size wlf_rect_get_size(const struct wlf_rect *rect);
+
+/**
+ * @brief Gets the center point of the rectangle.
+ * @param rect Source rectangle.
+ * @return Center point.
+ */
+struct wlf_point wlf_rect_get_center(const struct wlf_rect *rect);
+
+/**
+ * @brief Gets the top-left corner of the rectangle.
+ * @param rect Source rectangle.
+ * @return Top-left point.
+ */
+struct wlf_point wlf_rect_get_top_left(const struct wlf_rect *rect);
+
+/**
+ * @brief Gets the bottom-right corner of the rectangle.
+ * @param rect Source rectangle.
+ * @return Bottom-right point.
+ */
+struct wlf_point wlf_rect_get_bottom_right(const struct wlf_rect *rect);
+
+/**
+ * @brief Calculates the area of the rectangle.
+ * @param rect Source rectangle.
+ * @return Area of the rectangle.
+ */
+int wlf_rect_area(const struct wlf_rect *rect);
+
+/**
+ * @brief Calculates the perimeter of the rectangle.
+ * @param rect Source rectangle.
+ * @return Perimeter of the rectangle.
+ */
+int wlf_rect_perimeter(const struct wlf_rect *rect);
+
+/**
+ * @brief Moves rectangle by given offset.
+ * @param rect Rectangle to move.
+ * @param offset Movement offset.
+ * @return Moved rectangle.
+ */
+struct wlf_rect wlf_rect_offset(const struct wlf_rect *rect, const struct wlf_point *offset);
+
+/**
+ * @brief Inflates rectangle by given amount.
+ * @param rect Rectangle to inflate.
+ * @param dx Horizontal inflation.
+ * @param dy Vertical inflation.
+ * @return Inflated rectangle.
+ */
+struct wlf_rect wlf_rect_inflate(const struct wlf_rect *rect, int dx, int dy);
+
+/**
+ * @brief Scales rectangle by given factors.
+ * @param rect Rectangle to scale.
+ * @param sx Horizontal scale factor.
+ * @param sy Vertical scale factor.
+ * @return Scaled rectangle.
+ */
+struct wlf_rect wlf_rect_scale(const struct wlf_rect *rect, double sx, double sy);
+
+/**
+ * @brief Checks if point with double coordinates is inside rectangle.
+ * @param rect Rectangle to check.
+ * @param x X coordinate of the point.
+ * @param y Y coordinate of the point.
+ * @return true if point is inside rectangle, false otherwise.
+ */
+bool wlf_rect_contains_point_d(const struct wlf_rect *rect, double x, double y);
+
+/**
+ * @brief Checks if point is inside rectangle.
+ * @param rect Rectangle to check.
+ * @param point Point to test.
+ * @return true if point is inside rectangle, false otherwise.
+ */
+bool wlf_rect_contains_point(const struct wlf_rect *rect, const struct wlf_point *point);
+
+/**
+ * @brief Checks if one rectangle contains another.
+ * @param outer Outer rectangle.
+ * @param inner Inner rectangle to test.
+ * @return true if outer contains inner, false otherwise.
+ */
+bool wlf_rect_contains_rect(const struct wlf_rect *outer, const struct wlf_rect *inner);
+
+/**
+ * @brief Checks if two rectangles intersect.
+ * @param a First rectangle.
+ * @param b Second rectangle.
+ * @return true if rectangles intersect, false otherwise.
+ */
+bool wlf_rect_intersects(const struct wlf_rect *a, const struct wlf_rect *b);
+
+/**
+ * @brief Calculates intersection of two rectangles.
+ * @param a First rectangle.
+ * @param b Second rectangle.
+ * @return Intersection rectangle (empty if no intersection).
+ */
+struct wlf_rect wlf_rect_intersection(const struct wlf_rect *a, const struct wlf_rect *b);
+
+/**
+ * @brief Calculates union (bounding box) of two rectangles.
+ * @param a First rectangle.
+ * @param b Second rectangle.
+ * @return Union rectangle.
+ */
+struct wlf_rect wlf_rect_union(const struct wlf_rect *a, const struct wlf_rect *b);
+
+/**
+ * @brief Parses a string representation of a rectangle and creates a wlf_rect structure.
+ * @param str String representation of rectangle in format "(x,y,width,height)"
+ *             or "(x, y, width, height)".
+ * @param rect Pointer to the rectangle structure to fill.
+ * @return true if parsing was successful, false otherwise.
+ */
+bool wlf_rect_from_str(const char *str, struct wlf_rect *rect);
+
+#endif // MATH_WLF_RECT_H

--- a/include/wlf/math/wlf_region.h
+++ b/include/wlf/math/wlf_region.h
@@ -1,0 +1,127 @@
+/**
+ * @file        wlf_region.h
+ * @brief       2D region math utility for wlframe.
+ * @details     This file provides structures and functions for 2D region operations (region is a set of rectangles),
+ *              including creation, destruction, initialization, cleanup, emptiness check, rectangle addition,
+ *              point containment, rectangle intersection, union, and intersection.
+ * @author      YaoBing Xiao
+ * @date        2024-05-20
+ * @version     v1.0
+ * @par Copyright(c):
+ * @par History:
+ *      version: v1.0, YaoBing Xiao, 2024-05-20, initial version\n
+ */
+
+#ifndef MATH_WLF_REGION_H
+#define MATH_WLF_REGION_H
+
+#include "wlf/math/wlf_frect.h"
+
+#include <stddef.h>
+#include <stdbool.h>
+#include <string.h>
+#include <stdlib.h>
+#include <stdio.h>
+
+/**
+ * @brief Region data structure, contains an array of rectangles and its size.
+ */
+struct wlf_region_data {
+	long size;                /**< Capacity of the data area */
+	long numRects;            /**< Number of rectangles */
+	struct wlf_frect *rects;   /**< Pointer to rectangle array */
+};
+
+/**
+ * @brief Region structure, contains bounding rectangle and data pointer.
+ */
+struct wlf_region {
+	struct wlf_frect extents;           /**< Bounding rectangle of the region */
+	struct wlf_region_data *data;      /**< Pointer to region data */
+};
+
+/**
+ * @brief Initialize a region object.
+ * @param region Pointer to the region object.
+ */
+void wlf_region_init(struct wlf_region *region);
+
+/**
+ * @brief Finalize a region object and release its resources.
+ * @param region Pointer to the region object.
+ */
+void wlf_region_fini(struct wlf_region *region);
+
+/**
+ * @brief Converts a region to a string representation.
+ * @param region Source region.
+ * @return A string representing the region.
+ */
+char* wlf_region_to_str(const struct wlf_region *region);
+
+/**
+ * @brief Parse a region from a string representation.
+ * @param str The input string. eg: {[0, 0, 100, 100], [150, 150, 50, 50], ....}
+ * @param out_region Pointer to the region object to fill.
+ * @return true if parsing succeeded, false otherwise.
+ */
+bool wlf_region_from_str(const char *str, struct wlf_region *out_region);
+
+/**
+ * @brief Get the bounding rectangle of the region.
+ * @param region Pointer to the region object.
+ * @return The bounding rectangle of the region.
+ */
+struct wlf_frect wlf_region_bounding_rect(const struct wlf_region *region);
+
+/**
+ * @brief Check if the region is empty (no valid rectangles).
+ * @param region Pointer to the region object.
+ * @return true if empty, false otherwise.
+ */
+bool wlf_region_is_nil(const struct wlf_region *region);
+
+/**
+ * @brief Add a rectangle to the region.
+ * @param region Pointer to the region object.
+ * @param rect Pointer to the rectangle to add.
+ * @return true if added successfully, false otherwise.
+ */
+bool wlf_region_add_rect(struct wlf_region *region, const struct wlf_frect *rect);
+
+/**
+ * @brief Check if a point is inside the region.
+ * @param region Pointer to the region object.
+ * @param x X coordinate of the point.
+ * @param y Y coordinate of the point.
+ * @return true if the point is inside, false otherwise.
+ */
+bool wlf_region_contains_point(const struct wlf_region *region, double x, double y);
+
+/**
+ * @brief Check if the region intersects with a given rectangle.
+ * @param region Pointer to the region object.
+ * @param rect Pointer to the rectangle to test.
+ * @param result Pointer to the region object where the intersection result will be written.
+ * If the intersection is empty, the result will be an empty region.
+ */
+void wlf_region_intersects_rect(const struct wlf_region *region, const struct wlf_frect *rect,
+	struct wlf_region *result);
+
+/**
+ * @brief Compute the union of two regions.
+ * @param dst Destination region object pointer, result will be written here.
+ * @param src Source region object pointer.
+ */
+void wlf_region_union(struct wlf_region *dst, const struct wlf_region *src);
+
+/**
+ * @brief Compute the intersection of two regions.
+ * @param dst First region object pointer.
+ * @param src Second region object pointer.
+ * @param result Pointer to the region object where the intersection result will be written.
+ * If the intersection is empty, the result will be an empty region.
+ */
+void wlf_region_intersect(const struct wlf_region *dst, const struct wlf_region *src, struct wlf_region *result);
+
+#endif // MATH_WLF_REGION_H

--- a/include/wlf/math/wlf_size.h
+++ b/include/wlf/math/wlf_size.h
@@ -1,0 +1,106 @@
+/**
+ * @file        wlf_size.h
+ * @brief       2D integer size math utility for wlframe.
+ * @details     This file provides structures and functions for 2D integer size operations,
+ *              including creation, conversion, arithmetic, comparison, and rounding.
+ * @author      YaoBing Xiao
+ * @date        2024-05-20
+ * @version     v1.0
+ * @par Copyright(c):
+ * @par History:
+ *      version: v1.0, YaoBing Xiao, 2024-05-20, initial version\n
+ */
+
+#ifndef MATH_WLF_SIZE_H
+#define MATH_WLF_SIZE_H
+
+#include <stdbool.h>
+
+/**
+ * @brief A structure representing a 2D integer size.
+ */
+struct wlf_size {
+	int width;   /**< The width value */
+	int height;  /**< The height value */
+};
+
+static const struct wlf_size WLF_SIZE_ZERO = {0, 0};        /**< Zero size (0,0) */
+static const struct wlf_size WLF_SIZE_UNIT = {1, 1};        /**< Unit size (1,1) */
+
+/**
+ * @brief Converts a size to a string representation.
+ * @param size Source size.
+ * @return A string representing the size.
+ */
+char* wlf_size_to_str(const struct wlf_size *size);
+
+/**
+ * @brief Checks if two sizes are equal.
+ * @param a First size.
+ * @param b Second size.
+ * @return true if sizes are equal, false otherwise.
+ */
+bool wlf_size_equal(const struct wlf_size *a, const struct wlf_size *b);
+
+/**
+ * @brief Checks if size is empty (zero width or height).
+ * @param size Size to check.
+ * @return true if size is empty, false otherwise.
+ */
+bool wlf_size_is_empty(const struct wlf_size *size);
+
+/**
+ * @brief Adds two sizes.
+ * @param a First size.
+ * @param b Second size.
+ * @return Result of a + b.
+ */
+struct wlf_size wlf_size_add(const struct wlf_size *a, const struct wlf_size *b);
+
+/**
+ * @brief Subtracts two sizes.
+ * @param a First size.
+ * @param b Second size.
+ * @return Result of a - b.
+ */
+struct wlf_size wlf_size_subtract(const struct wlf_size *a, const struct wlf_size *b);
+
+/**
+ * @brief Multiplies a size by a scalar.
+ * @param size Size to multiply.
+ * @param scalar Scalar value.
+ * @return Scaled size.
+ */
+struct wlf_size wlf_size_multiply(const struct wlf_size *size, double scalar);
+
+/**
+ * @brief Divides a size by a scalar.
+ * @param size Size to divide.
+ * @param scalar Scalar value.
+ * @return Divided size.
+ */
+struct wlf_size wlf_size_divide(const struct wlf_size *size, double scalar);
+
+/**
+ * @brief Calculates the area of the size.
+ * @param size Size to calculate area for.
+ * @return Area (width * height).
+ */
+int wlf_size_area(const struct wlf_size *size);
+
+/**
+ * @brief Converts a string representation of a point to a wlf_size structure.
+ * @param str String in the format "(width, height)".
+ * @param point Pointer to the wlf_size structure to fill.
+ * @return true if conversion was successful, false otherwise.
+ */
+bool wlf_size_from_str(const char *str, struct wlf_size *size);
+
+/**
+ * @brief Checks if a integer size is valid.
+ * @param size Size to validate.
+ * @return true if size is valid (width > 0 and height > 0), false otherwise.
+ */
+bool wlf_size_is_valid(const struct wlf_size *size);
+
+#endif // MATH_WLF_SIZE_H

--- a/include/wlf/math/wlf_vector2.h
+++ b/include/wlf/math/wlf_vector2.h
@@ -1,0 +1,119 @@
+/**
+ * @file        wlf_vector2.h
+ * @brief       2D vector math utility for wlframe.
+ * @details     This file provides a structure and functions for 2D vector operations,
+ *              including creation, conversion, arithmetic, normalization, dot product,
+ *              magnitude calculation, and comparison.
+ * @author      YaoBing Xiao
+ * @date        2024-05-20
+ * @version     v1.0
+ * @par Copyright(c):
+ * @par History:
+ *      version: v1.0, YaoBing Xiao, 2024-05-20, initial version\n
+ */
+
+#ifndef MATH_WLF_VECTOR2_H
+#define MATH_WLF_VECTOR2_H
+
+#include <stdbool.h>
+#include <stdint.h>
+
+/**
+ * @brief A structure representing a 2D vector.
+ */
+struct wlf_vector2 {
+	double u;  /**< The u component (x-axis) */
+	double v;  /**< The v component (y-axis) */
+};
+
+static const struct wlf_vector2 WLF_VECTOR2_ZERO = {0.0, 0.0};    /**< Zero vector (0,0) */
+static const struct wlf_vector2 WLF_VECTOR2_UNIT_U = {1.0, 0.0};  /**< Unit vector in u direction (1,0) */
+static const struct wlf_vector2 WLF_VECTOR2_UNIT_V = {0.0, 1.0};  /**< Unit vector in v direction (0,1) */
+
+/**
+ * @brief Converts a 2D vector to a string representation.
+ * @param vector Source 2D vector.
+ * @return A string representing the 2D vector.
+ */
+char* wlf_vector2_to_str(const struct wlf_vector2 *vector);
+
+/**
+ * @brief Converts a 2D vector to a string representation with specified precision.
+ * @param size Source 2D vector vector.
+ * @param precision Number of decimal places (0-15).
+ * @return A string representing the 2D vector, or NULL if memory allocation fails.
+ */
+char *wlf_vector2_to_str_prec(const struct wlf_vector2 *vector, uint8_t precision);
+
+/**
+ * @brief Adds two vectors.
+ * @param a First vector.
+ * @param b Second vector.
+ * @return Result of a + b.
+ */
+struct wlf_vector2 wlf_vector2_add(const struct wlf_vector2 *a, const struct wlf_vector2 *b);
+
+/**
+ * @brief Subtracts two vectors.
+ * @param a First vector.
+ * @param b Second vector.
+ * @return Result of a - b.
+ */
+struct wlf_vector2 wlf_vector2_subtract(const struct wlf_vector2 *a, const struct wlf_vector2 *b);
+
+/**
+ * @brief Multiplies a vector by a scalar.
+ * @param vec Vector to multiply.
+ * @param scalar Scalar value.
+ * @return Scaled vector.
+ */
+struct wlf_vector2 wlf_vector2_multiply(const struct wlf_vector2 *vec, double scalar);
+
+/**
+ * @brief Divides a vector by a scalar.
+ * @param vec Vector to divide.
+ * @param scalar Scalar value (must not be zero).
+ * @return Divided vector.
+ */
+struct wlf_vector2 wlf_vector2_divide(const struct wlf_vector2 *vec, double scalar);
+
+/**
+ * @brief Calculates the dot product of two vectors.
+ * @param a First vector.
+ * @param b Second vector.
+ * @return Dot product (a·b).
+ */
+double wlf_vector2_dot(const struct wlf_vector2 *a, const struct wlf_vector2 *b);
+
+/**
+ * @brief Calculates the magnitude (length) of a vector.
+ * @param vec Input vector.
+ * @return Magnitude of the vector.
+ */
+double wlf_vector2_magnitude(const struct wlf_vector2 *vec);
+
+/**
+ * @brief Normalizes a vector to unit length.
+ * @param vec Vector to normalize.
+ * @return Normalized vector.
+ */
+struct wlf_vector2 wlf_vector2_normalize(const struct wlf_vector2 *vec);
+
+/**
+ * @brief Checks if two vectors are equal.
+ * @param a First vector.
+ * @param b Second vector.
+ * @return true if vectors are equal, false otherwise.
+ */
+bool wlf_vector2_equal(const struct wlf_vector2 *a, const struct wlf_vector2 *b);
+
+/**
+ * @brief Checks if two vectors are nearly equal within epsilon.
+ * @param a First vector.
+ * @param b Second vector.
+ * @param epsilon Maximum allowed difference.
+ * @return true if vectors are nearly equal, false otherwise.
+ */
+bool wlf_vector2_nearly_equal(const struct wlf_vector2 *a, const struct wlf_vector2 *b, double epsilon);
+
+#endif // MATH_WLF_VECTOR2_H

--- a/include/wlf/math/wlf_vector3.h
+++ b/include/wlf/math/wlf_vector3.h
@@ -1,0 +1,142 @@
+/**
+ * @file        wlf_vector3.h
+ * @brief       3D vector math utility for wlframe.
+ * @details     This file provides a structure and functions for 3D vector operations,
+ *              including creation, conversion, arithmetic, normalization, dot and cross product,
+ *              magnitude calculation, and comparison.
+ * @author      YaoBing Xiao
+ * @date        2024-05-20
+ * @version     v1.0
+ * @par Copyright(c):
+ * @par History:
+ *      version: v1.0, YaoBing Xiao, 2024-05-20, initial version\n
+ */
+
+#ifndef MATH_WLF_VECTOR3_H
+#define MATH_WLF_VECTOR3_H
+
+#include <stdbool.h>
+#include <stdint.h>
+
+/**
+ * @brief A structure representing a 3D vector.
+ */
+struct wlf_vector3 {
+	double x;  /**< The x component */
+	double y;  /**< The y component */
+	double z;  /**< The z component */
+};
+
+static const struct wlf_vector3 WLF_VECTOR3_ZERO   = {0.0, 0.0, 0.0};    /**< Zero vector (0,0,0) */
+static const struct wlf_vector3 WLF_VECTOR3_UNIT_X = {1.0, 0.0, 0.0};    /**< Unit vector in x direction (1,0,0) */
+static const struct wlf_vector3 WLF_VECTOR3_UNIT_Y = {0.0, 1.0, 0.0};    /**< Unit vector in y direction (0,1,0) */
+static const struct wlf_vector3 WLF_VECTOR3_UNIT_Z = {0.0, 0.0, 1.0};    /**< Unit vector in z direction (0,0,1) */
+
+/**
+ * @brief Make a new 3D vector from x, y, and z components.
+ * @param x X component of the vector.
+ * @param y Y component of the vector.
+ * @param z Z component of the vector.
+ * @return A new wlf_vector3 structure with the specified components.
+ */
+struct wlf_vector3 wlf_vector3_make(double x, double y, double z);
+
+/**
+ * @brief Converts a 3D vector to a string representation.
+ * @param vector Source 3D vector to convert.
+ * @return A dynamically allocated string representing the 3D vector in format "(x,y,z)",
+ *         or NULL if memory allocation fails. The caller is responsible for freeing the returned string.
+ */
+char* wlf_vector3_to_str(const struct wlf_vector3 *vector);
+
+/**
+ * @brief Converts a 3D vector to a string representation with specified precision.
+ * @param size Source 3D vector.
+ * @param precision Number of decimal places (0-15).
+ * @return A string representing the 3D vector, or NULL if memory allocation fails.
+ */
+char *wlf_vector3_to_str_prec(const struct wlf_vector3 *vector, uint8_t precision);
+
+/**
+ * @brief Adds two 3D vectors component-wise.
+ * @param a First vector operand.
+ * @param b Second vector operand.
+ * @return A new vector representing the sum (a + b).
+ */
+struct wlf_vector3 wlf_vector3_add(const struct wlf_vector3 *a, const struct wlf_vector3 *b);
+
+/**
+ * @brief Subtracts two 3D vectors component-wise.
+ * @param a First vector operand (minuend).
+ * @param b Second vector operand (subtrahend).
+ * @return A new vector representing the difference (a - b).
+ */
+struct wlf_vector3 wlf_vector3_subtract(const struct wlf_vector3 *a, const struct wlf_vector3 *b);
+
+/**
+ * @brief Multiplies a 3D vector by a scalar value.
+ * @param vec Vector to multiply.
+ * @param scalar Scalar multiplier.
+ * @return A new vector with each component multiplied by the scalar.
+ */
+struct wlf_vector3 wlf_vector3_multiply(const struct wlf_vector3 *vec, double scalar);
+
+/**
+ * @brief Divides a 3D vector by a scalar value.
+ * @param vec Vector to divide.
+ * @param scalar Scalar divisor (must not be zero).
+ * @return A new vector with each component divided by the scalar.
+ * @warning Behavior is undefined if scalar is zero.
+ */
+struct wlf_vector3 wlf_vector3_divide(const struct wlf_vector3 *vec, double scalar);
+
+/**
+ * @brief Calculates the dot product of two 3D vectors.
+ * @param a First vector operand.
+ * @param b Second vector operand.
+ * @return The dot product (a·b) as a scalar value.
+ */
+double wlf_vector3_dot(const struct wlf_vector3 *a, const struct wlf_vector3 *b);
+
+/**
+ * @brief Calculates the cross product of two 3D vectors.
+ * @param a First vector operand.
+ * @param b Second vector operand.
+ * @return A new vector representing the cross product (a×b), perpendicular to both input vectors.
+ */
+struct wlf_vector3 wlf_vector3_cross(const struct wlf_vector3 *a, const struct wlf_vector3 *b);
+
+/**
+ * @brief Calculates the magnitude (length) of a 3D vector.
+ * @param vec Input vector.
+ * @return The magnitude of the vector as a non-negative scalar value.
+ */
+double wlf_vector3_magnitude(const struct wlf_vector3 *vec);
+
+/**
+ * @brief Normalizes a 3D vector to unit length.
+ * @param vec Vector to normalize.
+ * @return A new vector with the same direction but magnitude of 1.0.
+ * @warning Behavior is undefined if the input vector has zero magnitude.
+ */
+struct wlf_vector3 wlf_vector3_normalize(const struct wlf_vector3 *vec);
+
+/**
+ * @brief Checks if two 3D vectors are exactly equal.
+ * @param a First vector to compare.
+ * @param b Second vector to compare.
+ * @return true if vectors are exactly equal (all components match), false otherwise.
+ */
+bool wlf_vector3_equal(const struct wlf_vector3 *a, const struct wlf_vector3 *b);
+
+/**
+ * @brief Checks if two 3D vectors are approximately equal within an epsilon tolerance.
+ * @param a First vector to compare.
+ * @param b Second vector to compare.
+ * @param epsilon Maximum allowed difference between corresponding components.
+ * @return true if the absolute difference between all corresponding components is less than epsilon,
+ *         false otherwise.
+ */
+bool wlf_vector3_nearly_equal(const struct wlf_vector3 *a, const struct wlf_vector3 *b, double epsilon);
+
+#endif // MATH_WLF_VECTOR3_H

--- a/include/wlf/math/wlf_vector4.h
+++ b/include/wlf/math/wlf_vector4.h
@@ -1,0 +1,133 @@
+/**
+ * @file        wlf_vector4.h
+ * @brief       4D vector math utility for wlframe.
+ * @details     This file provides a structure and functions for 4D vector operations,
+ *              including creation, conversion, arithmetic, normalization, dot product,
+ *              magnitude calculation, and comparison.
+ * @author      YaoBing Xiao
+ * @date        2024-05-20
+ * @version     v1.0
+ * @par Copyright(c):
+ * @par History:
+ *      version: v1.0, YaoBing Xiao, 2024-05-20, initial version\n
+ */
+
+#ifndef MATH_WLF_VECTOR4_H
+#define MATH_WLF_VECTOR4_H
+
+#include <stdbool.h>
+#include <stdint.h>
+
+/**
+ * @brief A structure representing a 4D vector.
+ */
+struct wlf_vector4 {
+	double x;  /**< The x component */
+	double y;  /**< The y component */
+	double z;  /**< The z component */
+	double w;  /**< The w component */
+};
+
+static const struct wlf_vector4 WLF_VECTOR4_ZERO   = {0.0, 0.0, 0.0, 0.0};    /**< Zero vector (0,0,0,0) */
+static const struct wlf_vector4 WLF_VECTOR4_UNIT_X = {1.0, 0.0, 0.0, 0.0};    /**< Unit vector in x direction (1,0,0,0) */
+static const struct wlf_vector4 WLF_VECTOR4_UNIT_Y = {0.0, 1.0, 0.0, 0.0};    /**< Unit vector in y direction (0,1,0,0) */
+static const struct wlf_vector4 WLF_VECTOR4_UNIT_Z = {0.0, 0.0, 1.0, 0.0};    /**< Unit vector in z direction (0,0,1,0) */
+static const struct wlf_vector4 WLF_VECTOR4_UNIT_W = {0.0, 0.0, 0.0, 1.0};    /**< Unit vector in w direction (0,0,0,1) */
+
+/**
+ * @brief  Make a new 4D vector from x, y, and z components.
+ * @param x The x component.
+ * @param y The y component.
+ * @param z The z component.
+ * @param w The w component.
+ * @return A new wlf_vector4 structure.
+ */
+struct wlf_vector4 wlf_vector4_make(double x, double y, double z, double w);
+
+/**
+ * @brief Converts a 4D vector to a string representation.
+ * @param vector Source 4D vector.
+ * @return A string representing the 4D vector.
+ */
+char* wlf_vector4_to_str(const struct wlf_vector4 *vector);
+
+/**
+ * @brief Converts a 4D vector to a string representation with specified precision.
+ * @param size Source 4D vector.
+ * @param precision Number of decimal places (0-15).
+ * @return A string representing the 4D vector, or NULL if memory allocation fails.
+ */
+char *wlf_vector4_to_str_prec(const struct wlf_vector4 *vector, uint8_t precision);
+
+/**
+ * @brief Adds two vectors.
+ * @param a First vector.
+ * @param b Second vector.
+ * @return Result of a + b.
+ */
+struct wlf_vector4 wlf_vector4_add(const struct wlf_vector4 *a, const struct wlf_vector4 *b);
+
+/**
+ * @brief Subtracts two vectors.
+ * @param a First vector.
+ * @param b Second vector.
+ * @return Result of a - b.
+ */
+struct wlf_vector4 wlf_vector4_subtract(const struct wlf_vector4 *a, const struct wlf_vector4 *b);
+
+/**
+ * @brief Multiplies a vector by a scalar.
+ * @param vec Vector to multiply.
+ * @param scalar Scalar value.
+ * @return Scaled vector.
+ */
+struct wlf_vector4 wlf_vector4_multiply(const struct wlf_vector4 *vec, double scalar);
+
+/**
+ * @brief Divides a vector by a scalar.
+ * @param vec Vector to divide.
+ * @param scalar Scalar value (must not be zero).
+ * @return Divided vector.
+ */
+struct wlf_vector4 wlf_vector4_divide(const struct wlf_vector4 *vec, double scalar);
+
+/**
+ * @brief Calculates the dot product of two vectors.
+ * @param a First vector.
+ * @param b Second vector.
+ * @return Dot product (a·b).
+ */
+double wlf_vector4_dot(const struct wlf_vector4 *a, const struct wlf_vector4 *b);
+
+/**
+ * @brief Calculates the magnitude (length) of a vector.
+ * @param vec Input vector.
+ * @return Magnitude of the vector.
+ */
+double wlf_vector4_magnitude(const struct wlf_vector4 *vec);
+
+/**
+ * @brief Normalizes a vector to unit length.
+ * @param vec Vector to normalize.
+ * @return Normalized vector.
+ */
+struct wlf_vector4 wlf_vector4_normalize(const struct wlf_vector4 *vec);
+
+/**
+ * @brief Checks if two vectors are equal.
+ * @param a First vector.
+ * @param b Second vector.
+ * @return true if vectors are equal, false otherwise.
+ */
+bool wlf_vector4_equal(const struct wlf_vector4 *a, const struct wlf_vector4 *b);
+
+/**
+ * @brief Checks if two vectors are nearly equal within epsilon.
+ * @param a First vector.
+ * @param b Second vector.
+ * @param epsilon Maximum allowed difference.
+ * @return true if vectors are nearly equal, false otherwise.
+ */
+bool wlf_vector4_nearly_equal(const struct wlf_vector4 *a, const struct wlf_vector4 *b, double epsilon);
+
+#endif // MATH_WLF_VECTOR4_H

--- a/math/meson.build
+++ b/math/meson.build
@@ -5,4 +5,5 @@ wlf_files += files(
 	'wlf_fsize.c',
 	'wlf_rect.c',
 	'wlf_frect.c',
+	'wlf_vector2.c',
 )

--- a/math/meson.build
+++ b/math/meson.build
@@ -3,4 +3,6 @@ wlf_files += files(
 	'wlf_fpoint.c',
 	'wlf_size.c',
 	'wlf_fsize.c',
+	'wlf_rect.c',
+	'wlf_frect.c',
 )

--- a/math/meson.build
+++ b/math/meson.build
@@ -13,4 +13,5 @@ wlf_files += files(
 	'wlf_quaternion.c',
 	'wlf_matrix3x3.c',
 	'wlf_matrix4x4.c',
+	'wlf_region.c',
 )

--- a/math/meson.build
+++ b/math/meson.build
@@ -7,4 +7,5 @@ wlf_files += files(
 	'wlf_frect.c',
 	'wlf_vector2.c',
 	'wlf_vector3.c',
+	'wlf_vector4.c',
 )

--- a/math/meson.build
+++ b/math/meson.build
@@ -8,4 +8,6 @@ wlf_files += files(
 	'wlf_vector2.c',
 	'wlf_vector3.c',
 	'wlf_vector4.c',
+	'wlf_ray2.c',
+	'wlf_ray3.c',
 )

--- a/math/meson.build
+++ b/math/meson.build
@@ -11,4 +11,5 @@ wlf_files += files(
 	'wlf_ray2.c',
 	'wlf_ray3.c',
 	'wlf_quaternion.c',
+	'wlf_matrix3x3.c',
 )

--- a/math/meson.build
+++ b/math/meson.build
@@ -1,0 +1,4 @@
+wlf_files += files(
+	'wlf_point.c',
+	'wlf_fpoint.c',
+)

--- a/math/meson.build
+++ b/math/meson.build
@@ -1,4 +1,6 @@
 wlf_files += files(
 	'wlf_point.c',
 	'wlf_fpoint.c',
+	'wlf_size.c',
+	'wlf_fsize.c',
 )

--- a/math/meson.build
+++ b/math/meson.build
@@ -12,4 +12,5 @@ wlf_files += files(
 	'wlf_ray3.c',
 	'wlf_quaternion.c',
 	'wlf_matrix3x3.c',
+	'wlf_matrix4x4.c',
 )

--- a/math/meson.build
+++ b/math/meson.build
@@ -6,4 +6,5 @@ wlf_files += files(
 	'wlf_rect.c',
 	'wlf_frect.c',
 	'wlf_vector2.c',
+	'wlf_vector3.c',
 )

--- a/math/meson.build
+++ b/math/meson.build
@@ -10,4 +10,5 @@ wlf_files += files(
 	'wlf_vector4.c',
 	'wlf_ray2.c',
 	'wlf_ray3.c',
+	'wlf_quaternion.c',
 )

--- a/math/wlf_fpoint.c
+++ b/math/wlf_fpoint.c
@@ -1,0 +1,204 @@
+#include "wlf/math/wlf_fpoint.h"
+#include "wlf/utils/wlf_log.h"
+
+#include <stdlib.h>
+#include <stdio.h>
+#include <math.h>
+#include <string.h>
+#include <assert.h>
+
+#define WLF_FPOINT_STRLEN 128
+
+char *wlf_fpoint_to_str(const struct wlf_fpoint *point) {
+	return wlf_fpoint_to_str_prec(point, 3);
+}
+
+char *wlf_fpoint_to_str_prec(const struct wlf_fpoint *point, uint8_t precision) {
+	if (point == NULL) {
+		return strdup("(NULL)");
+	}
+
+	if (precision > 15) {
+		precision = 15;
+	}
+
+	char fmt[32];
+	snprintf(fmt, sizeof(fmt), "(%%.%df, %%.%df)", precision, precision);
+
+	char *buffer = malloc(WLF_FPOINT_STRLEN);
+	if (buffer == NULL) {
+		wlf_log(WLF_ERROR, "Memory allocation failed for wlf_fpoint_to_str_prec");
+		return NULL;
+	}
+
+	snprintf(buffer, WLF_FPOINT_STRLEN, fmt, point->x, point->y);
+
+	return buffer;
+}
+
+bool wlf_fpoint_equal(const struct wlf_fpoint *a, const struct wlf_fpoint *b) {
+	return (a->x == b->x) && (a->y == b->y);
+}
+
+bool wlf_fpoint_nearly_equal(const struct wlf_fpoint *a, const struct wlf_fpoint *b, double epsilon) {
+	return (fabs(a->x - b->x) < epsilon) && (fabs(a->y - b->y) < epsilon);
+}
+
+bool wlf_fpoint_is_zero(const struct wlf_fpoint *p) {
+	return (p->x == 0.0) && (p->y == 0.0);
+}
+
+struct wlf_fpoint wlf_fpoint_add(const struct wlf_fpoint *a, const struct wlf_fpoint *b) {
+	return (struct wlf_fpoint){.x = a->x + b->x, .y = a->y + b->y};
+}
+
+struct wlf_fpoint wlf_fpoint_subtract(const struct wlf_fpoint *a, const struct wlf_fpoint *b) {
+	return (struct wlf_fpoint){.x = a->x - b->x, .y = a->y - b->y};
+}
+
+struct wlf_fpoint wlf_fpoint_multiply(const struct wlf_fpoint *p, double scalar) {
+	return (struct wlf_fpoint){.x = p->x * scalar, .y = p->y * scalar};
+}
+
+struct wlf_fpoint wlf_fpoint_divide(const struct wlf_fpoint *p, double scalar) {
+	assert(scalar != 0.0);
+	return (struct wlf_fpoint){.x = p->x / scalar, .y = p->y / scalar};
+}
+
+struct wlf_fpoint wlf_fpoint_negate(const struct wlf_fpoint *p) {
+	return (struct wlf_fpoint){.x = -p->x, .y = -p->y};
+}
+
+double wlf_fpoint_manhattan_distance(const struct wlf_fpoint *p1, const struct wlf_fpoint *p2) {
+	return fabs(p1->x - p2->x) + fabs(p1->y - p2->y);
+}
+
+double wlf_fpoint_euclidean_distance(const struct wlf_fpoint *p1, const struct wlf_fpoint *p2) {
+	return sqrt(pow(p1->x - p2->x, 2) + pow(p1->y - p2->y, 2));
+}
+
+double wlf_fpoint_dot_product(const struct wlf_fpoint *a, const struct wlf_fpoint *b) {
+	return (a->x * b->x) + (a->y * b->y);
+}
+
+double wlf_fpoint_angle(const struct wlf_fpoint *p) {
+	return atan2(p->y, p->x);
+}
+
+double wlf_fpoint_angle_between(const struct wlf_fpoint *a, const struct wlf_fpoint *b) {
+	return wlf_fpoint_angle(b) - wlf_fpoint_angle(a);
+}
+
+struct wlf_fpoint wlf_fpoint_rotate(const struct wlf_fpoint *p, double angle_radians) {
+	double cos_angle = cos(angle_radians);
+	double sin_angle = sin(angle_radians);
+	return (struct wlf_fpoint){
+			.x = p->x * cos_angle - p->y * sin_angle,
+			.y = p->x * sin_angle + p->y * cos_angle
+		};
+}
+
+double wlf_fpoint_length(const struct wlf_fpoint *p) {
+	return sqrt(p->x * p->x + p->y * p->y);
+}
+
+double wlf_fpoint_length_squared(const struct wlf_fpoint *p) {
+	return (p->x * p->x + p->y * p->y);
+}
+
+bool wlf_fpoint_in_circle(const struct wlf_fpoint *p, const struct wlf_fpoint *center, double radius) {
+	return wlf_fpoint_euclidean_distance(p, center) <= radius;
+}
+
+struct wlf_point wlf_fpoint_round(const struct wlf_fpoint *p) {
+	return (struct wlf_point){.x = round(p->x), .y = round(p->y)};
+}
+
+struct wlf_point wlf_fpoint_floor(const struct wlf_fpoint *p) {
+	return (struct wlf_point){.x = floor(p->x), .y = floor(p->y)};
+}
+
+struct wlf_point wlf_fpoint_ceil(const struct wlf_fpoint *p) {
+	return (struct wlf_point){.x = ceil(p->x), .y = ceil(p->y)};
+}
+
+struct wlf_fpoint wlf_fpoint_normalize(const struct wlf_fpoint *p) {
+	double length = wlf_fpoint_length(p);
+	if (length == 0) {
+		return (struct wlf_fpoint){.x = 0, .y = 0};
+	}
+
+	return (struct wlf_fpoint){.x = p->x / length, .y = p->y / length};
+}
+
+struct wlf_fpoint wlf_fpoint_lerp(const struct wlf_fpoint *a, const struct wlf_fpoint *b, double t) {
+	return (struct wlf_fpoint){.x = a->x + (b->x - a->x) * t, .y = a->y + (b->y - a->y) * t};
+}
+
+struct wlf_fpoint wlf_fpoint_bezier(const struct wlf_fpoint *p0, const struct wlf_fpoint *p1,
+		const struct wlf_fpoint *p2, double t) {
+	double u = 1 - t;
+	return (struct wlf_fpoint){.x = u * u * p0->x + 2 * u * t * p1->x + t * t * p2->x,
+								.y = u * u * p0->y + 2 * u * t * p1->y + t * t * p2->y};
+}
+
+struct wlf_fpoint wlf_point_to_fpoint(const struct wlf_point *p) {
+	return (struct wlf_fpoint){.x = (double)p->x, .y = (double)p->y};
+}
+
+struct wlf_point wlf_fpoint_to_point(const struct wlf_fpoint *p) {
+	return (struct wlf_point){.x = (int)p->x, .y = (int)p->y};
+}
+
+bool wlf_fpoint_from_str(const char *str, struct wlf_fpoint *point) {
+	if (str == NULL || point == NULL) {
+		return false;
+	}
+
+	while (*str == ' ' || *str == '\t') {
+		str++;
+	}
+
+	if (*str != '(') {
+		return false;
+	}
+	str++;
+
+	char *endptr;
+	double x = strtod(str, &endptr);
+	if (endptr == str) {
+		return false;
+	}
+	str = endptr;
+
+	while (*str == ' ' || *str == '\t') {
+		str++;
+	}
+
+	if (*str != ',') {
+		return false;
+	}
+	str++;
+
+	while (*str == ' ' || *str == '\t') {
+		str++;
+	}
+
+	double y = strtod(str, &endptr);
+	if (endptr == str) {
+		return false;
+	}
+	str = endptr;
+
+	while (*str == ' ' || *str == '\t') {
+		str++;
+	}
+
+	if (*str != ')') {
+		return false;
+	}
+
+	point->x = x;
+	point->y = y;
+	return true;
+}

--- a/math/wlf_frect.c
+++ b/math/wlf_frect.c
@@ -1,0 +1,147 @@
+#include "wlf/math/wlf_frect.h"
+#include "wlf/math/wlf_fpoint.h"
+#include "wlf/math/wlf_fsize.h"
+#include "wlf/math/wlf_rect.h"
+#include "wlf/utils/wlf_log.h"
+
+#include <stdlib.h>
+#include <stdio.h>
+#include <math.h>
+#include <string.h>
+
+#define WLF_FRECT_STRLEN 256
+
+struct wlf_frect wlf_frect_make(double x, double y, double width, double height) {
+	struct wlf_frect frect = {
+		.x = x,
+		.y = y,
+		.width = width,
+		.height = height,
+	};
+
+	return frect;
+}
+
+struct wlf_frect wlf_frect_from_point_size(const struct wlf_fpoint *pos, const struct wlf_fsize *size) {
+	return wlf_frect_make(pos->x, pos->y, size->width, size->height);
+}
+
+struct wlf_frect wlf_frect_from_points(const struct wlf_fpoint *p1, const struct wlf_fpoint *p2) {
+	int x = fmin(p1->x, p2->x);
+	int y = fmin(p1->y, p2->y);
+	int width = fabs(p1->x - p2->x);
+	int height = fabs(p1->y - p2->y);
+
+	return wlf_frect_make(x, y, width, height);
+}
+
+char* wlf_frect_to_str_prec(const struct wlf_frect *rect, uint8_t precision) {
+	if (rect == NULL) {
+		return strdup("(NULL)");
+	}
+
+	if (precision > 15) {
+		precision = 15;
+	}
+
+	char fmt[64];
+	snprintf(fmt, sizeof(fmt), "(%%.%df, %%.%df, %%.%df, %%.%df)",
+		precision, precision, precision, precision);
+
+	char *buffer = malloc(WLF_FRECT_STRLEN);
+	if (buffer == NULL) {
+		wlf_log(WLF_ERROR, "Memory allocation failed for wlf_frect_to_str_prec");
+		return NULL;
+	}
+
+	snprintf(buffer, WLF_FRECT_STRLEN, fmt, rect->x, rect->y, rect->width, rect->height);
+
+	return buffer;
+}
+
+bool wlf_frect_equal(const struct wlf_frect *a, const struct wlf_frect *b) {
+	return (a->x == b->x) && (a->y == b->y) && (a->width == b->width) && (a->height == b->height);
+}
+
+bool wlf_frect_nearly_equal(const struct wlf_frect *a, const struct wlf_frect *b, double epsilon) {
+	return (fabs(a->x - b->x) < epsilon) && (fabs(a->y - b->y) < epsilon) &&
+			(fabs(a->width - b->width) < epsilon) && (fabs(a->height - b->height) < epsilon);
+}
+
+struct wlf_frect wlf_rect_to_frect(const struct wlf_rect *rect) {
+	return wlf_frect_make((double)rect->x, (double)rect->y, (double)rect->width, (double)rect->height);
+}
+
+struct wlf_rect wlf_frect_to_rect(const struct wlf_frect *rect) {
+	return wlf_rect_make((int)rect->x, (int)rect->y, (int)rect->width, (int)rect->height);
+}
+
+struct wlf_rect wlf_frect_round(const struct wlf_frect *rect) {
+	return wlf_rect_make(round(rect->x), round(rect->y), round(rect->width), round(rect->height));
+}
+
+struct wlf_rect wlf_frect_floor(const struct wlf_frect *rect) {
+	return wlf_rect_make(floor(rect->x), floor(rect->y), floor(rect->width), floor(rect->height));
+}
+
+struct wlf_rect wlf_frect_ceil(const struct wlf_frect *rect) {
+	return wlf_rect_make(ceil(rect->x), ceil(rect->y), ceil(rect->width), ceil(rect->height));
+}
+
+bool wlf_frect_is_valid(const struct wlf_frect *rect) {
+	if (rect == NULL) {
+		return false;
+	}
+	return (rect->width > 0.0) && (rect->height > 0.0);
+}
+
+bool wlf_frect_from_str(const char *str, struct wlf_frect *rect) {
+	if (str == NULL || rect == NULL) {
+		return false;
+	}
+
+	while (*str == ' ' || *str == '\t' || *str == '\n' || *str == '\r') {
+		str++;
+	}
+
+	if (*str == '\0') {
+		return false;
+	}
+
+	if (*str != '(') {
+		return false;
+	}
+	str++;
+
+	double x, y, width, height;
+	int parsed = sscanf(str, "%lf,%lf,%lf,%lf", &x, &y, &width, &height);
+
+	if (parsed != 4) {
+		parsed = sscanf(str, "%lf, %lf, %lf, %lf", &x, &y, &width, &height);
+	}
+
+	if (parsed != 4) {
+		return false;
+	}
+
+	char *end_ptr = strchr(str, ')');
+	if (end_ptr == NULL) {
+		return false;
+	}
+
+	end_ptr++;
+	while (*end_ptr == ' ' || *end_ptr == '\t' || *end_ptr == '\n' || *end_ptr == '\r') {
+		end_ptr++;
+	}
+
+	if (*end_ptr != '\0') {
+		return false;
+	}
+
+	rect->x = x;
+	rect->y = y;
+	rect->width = width;
+	rect->height = height;
+
+	return true;
+}

--- a/math/wlf_fsize.c
+++ b/math/wlf_fsize.c
@@ -1,0 +1,149 @@
+#include "wlf/math/wlf_fsize.h"
+#include "wlf/utils/wlf_log.h"
+
+#include <stdlib.h>
+#include <stdio.h>
+#include <math.h>
+#include <string.h>
+#include <assert.h>
+
+#define WLF_FSIZE_STRLEN 128
+
+char *wlf_fsize_to_str(const struct wlf_fsize *size) {
+	return wlf_fsize_to_str_prec(size, 3);
+}
+
+char *wlf_fsize_to_str_prec(const struct wlf_fsize *size, uint8_t precision) {
+	if (size == NULL) {
+		return strdup("(NULL)");
+	}
+
+	if (precision > 15) {
+		precision = 15;
+	}
+
+	char fmt[32];
+	snprintf(fmt, sizeof(fmt), "(%%.%df, %%.%df)", precision, precision);
+
+	char *buffer = malloc(WLF_FSIZE_STRLEN);
+	if (buffer == NULL) {
+		wlf_log(WLF_ERROR, "Memory allocation failed for wlf_fsize_to_str_prec");
+		return NULL;
+	}
+
+	snprintf(buffer, WLF_FSIZE_STRLEN, fmt, size->width, size->height);
+
+	return buffer;
+}
+
+bool wlf_fsize_equal(const struct wlf_fsize *a, const struct wlf_fsize *b) {
+	return (a->width == b->width) && (a->height == b->height);
+}
+
+bool wlf_fsize_nearly_equal(const struct wlf_fsize *a, const struct wlf_fsize *b, double epsilon) {
+	return (fabs(a->width - b->width) < epsilon) && (fabs(a->height - b->height) < epsilon);
+}
+
+struct wlf_fsize wlf_fsize_add(const struct wlf_fsize *a, const struct wlf_fsize *b) {
+	return (struct wlf_fsize){.width = a->width + b->width, .height = a->height + b->height};
+}
+
+struct wlf_fsize wlf_fsize_subtract(const struct wlf_fsize *a, const struct wlf_fsize *b) {
+	return (struct wlf_fsize){.width = a->width - b->width, .height = a->height - b->height};
+}
+
+struct wlf_fsize wlf_fsize_multiply(const struct wlf_fsize *size, double scalar) {
+	return (struct wlf_fsize){.width = size->width * scalar, .height = size->height * scalar};
+}
+
+struct wlf_fsize wlf_fsize_divide(const struct wlf_fsize *size, double scalar) {
+	assert(scalar != 0.0);
+	return (struct wlf_fsize){.width = size->width / scalar, .height = size->height / scalar};
+}
+
+double wlf_fsize_area(const struct wlf_fsize *size) {
+	return size->width * size->height;
+}
+
+struct wlf_fsize wlf_size_to_fsize(const struct wlf_size *size) {
+	struct wlf_fsize fsize = {(double)size->width, (double)size->height};
+	return fsize;
+}
+
+struct wlf_size wlf_fsize_to_size(const struct wlf_fsize *size) {
+	struct wlf_size isize = {(int)size->width, (int)size->height};
+	return isize;
+}
+
+struct wlf_size wlf_fsize_round(const struct wlf_fsize *size) {
+	return (struct wlf_size){.width = round(size->width), .height = round(size->height)};
+}
+
+struct wlf_size wlf_fsize_floor(const struct wlf_fsize *size) {
+	return (struct wlf_size){.width = floor(size->width), .height = floor(size->height)};
+}
+
+struct wlf_size wlf_fsize_ceil(const struct wlf_fsize *size) {
+	return (struct wlf_size){.width = ceil(size->width), .height = ceil(size->height)};
+}
+
+bool wlf_fsize_from_str(const char *str, struct wlf_fsize *size) {
+	if (str == NULL || size == NULL) {
+		return false;
+	}
+
+	while (*str == ' ' || *str == '\t') {
+		str++;
+	}
+
+	if (*str != '(') {
+		return false;
+	}
+	str++;
+
+	char *endptr;
+	double width = strtod(str, &endptr);
+	if (endptr == str) {
+		return false;
+	}
+	str = endptr;
+
+	while (*str == ' ' || *str == '\t') {
+		str++;
+	}
+
+	if (*str != ',') {
+		return false;
+	}
+	str++;
+
+	while (*str == ' ' || *str == '\t') {
+		str++;
+	}
+
+	double height = strtod(str, &endptr);
+	if (endptr == str) {
+		return false;
+	}
+	str = endptr;
+
+	while (*str == ' ' || *str == '\t') {
+		str++;
+	}
+
+	if (*str != ')') {
+		return false;
+	}
+
+	size->width = width;
+	size->height = height;
+	return true;
+}
+
+bool wlf_fsize_is_valid(const struct wlf_fsize *size) {
+	if (size == NULL) {
+		return false;
+	}
+
+	return (size->width > 0.0) && (size->height > 0.0);
+}

--- a/math/wlf_matrix3x3.c
+++ b/math/wlf_matrix3x3.c
@@ -1,0 +1,163 @@
+#include "wlf/math/wlf_matrix3x3.h"
+#include "wlf/utils/wlf_log.h"
+
+#include <stdlib.h>
+#include <stdio.h>
+#include <string.h>
+#include <math.h>
+
+#define WLF_MATRIX3x3_STRLEN 128
+
+struct wlf_matrix3x3 wlf_matrix3x3_create_zero(void) {
+	struct wlf_matrix3x3 matrix = {0};
+
+	return matrix;
+}
+
+struct wlf_matrix3x3 wlf_matrix3x3_identity(void) {
+	struct wlf_matrix3x3 matrix = {0};
+	matrix.elements[0][0] = 1.0;
+	matrix.elements[1][1] = 1.0;
+	matrix.elements[2][2] = 1.0;
+
+	return matrix;
+}
+
+char* wlf_matrix3x3_to_str(const struct wlf_matrix3x3 *matrix) {
+	if (matrix == NULL) {
+		return strdup("(NULL)");
+	}
+
+	char *buffer = malloc(WLF_MATRIX3x3_STRLEN);
+	if (buffer == NULL) {
+		wlf_log(WLF_ERROR, "Memory allocation failed for wlf_matrix3x3_to_str");
+		return NULL;
+	}
+
+	snprintf(buffer, WLF_MATRIX3x3_STRLEN,
+		"[[%.3f, %.3f, %.3f],\n"
+		" [%.3f, %.3f, %.3f],\n"
+		" [%.3f, %.3f, %.3f]]",
+		matrix->elements[0][0], matrix->elements[0][1], matrix->elements[0][2],
+		matrix->elements[1][0], matrix->elements[1][1], matrix->elements[1][2],
+		matrix->elements[2][0], matrix->elements[2][1], matrix->elements[2][2]);
+
+	return buffer;
+}
+
+double wlf_matrix3x3_get(const struct wlf_matrix3x3 *matrix, int row, int col) {
+	return matrix->elements[row][col];
+}
+
+void wlf_matrix3x3_set(struct wlf_matrix3x3 *matrix, int row, int col, double value) {
+	matrix->elements[row][col] = value;
+}
+
+struct wlf_matrix3x3 wlf_matrix3x3_add(const struct wlf_matrix3x3 *a, const struct wlf_matrix3x3 *b) {
+	struct wlf_matrix3x3 result = {0};
+		for (int i = 0; i < 3; i++) {
+			for (int j = 0; j < 3; j++) {
+				result.elements[i][j] = a->elements[i][j] + b->elements[i][j];
+		}
+	}
+
+	return result;
+}
+
+struct wlf_matrix3x3 wlf_matrix3x3_subtract(const struct wlf_matrix3x3 *a, const struct wlf_matrix3x3 *b) {
+	struct wlf_matrix3x3 result = {0};
+	for (int i = 0; i < 3; i++) {
+		for (int j = 0; j < 3; j++) {
+			result.elements[i][j] = a->elements[i][j] - b->elements[i][j];
+		}
+	}
+
+	return result;
+}
+
+struct wlf_matrix3x3 wlf_matrix3x3_multiply_scalar(const struct wlf_matrix3x3 *matrix, double scalar) {
+	struct wlf_matrix3x3 result = {0};
+	for (int i = 0; i < 3; i++) {
+		for (int j = 0; j < 3; j++) {
+			result.elements[i][j] = matrix->elements[i][j] * scalar;
+		}
+	}
+
+	return result;
+}
+
+struct wlf_matrix3x3 wlf_matrix3x3_multiply(const struct wlf_matrix3x3 *a, const struct wlf_matrix3x3 *b) {
+	struct wlf_matrix3x3 result = {0};
+	for (int i = 0; i < 3; i++) {
+		for (int j = 0; j < 3; j++) {
+			for (int k = 0; k < 3; k++) {
+				result.elements[i][j] += a->elements[i][k] * b->elements[k][j];
+			}
+		}
+	}
+
+	return result;
+}
+
+struct wlf_matrix3x3 wlf_matrix3x3_transpose(const struct wlf_matrix3x3 *matrix) {
+	struct wlf_matrix3x3 result = {0};
+	for (int i = 0; i < 3; i++) {
+		for (int j = 0; j < 3; j++) {
+			result.elements[j][i] = matrix->elements[i][j];
+		}
+	}
+
+	return result;
+}
+
+double wlf_matrix3x3_determinant(const struct wlf_matrix3x3 *matrix) {
+	return matrix->elements[0][0] * (matrix->elements[1][1] * matrix->elements[2][2] - matrix->elements[1][2] * matrix->elements[2][1]) -
+			matrix->elements[0][1] * (matrix->elements[1][0] * matrix->elements[2][2] - matrix->elements[1][2] * matrix->elements[2][0]) +
+			matrix->elements[0][2] * (matrix->elements[1][0] * matrix->elements[2][1] - matrix->elements[1][1] * matrix->elements[2][0]);
+}
+
+struct wlf_matrix3x3 wlf_matrix3x3_inverse(const struct wlf_matrix3x3 *matrix) {
+	struct wlf_matrix3x3 result = {0};
+	double det = wlf_matrix3x3_determinant(matrix);
+
+	if (det == 0) {
+		// The matrix is not invertible, return a zero matrix
+		return result;
+	}
+
+	result.elements[0][0] = (matrix->elements[1][1] * matrix->elements[2][2] - matrix->elements[1][2] * matrix->elements[2][1]) / det;
+	result.elements[0][1] = (matrix->elements[0][2] * matrix->elements[2][1] - matrix->elements[0][1] * matrix->elements[2][2]) / det;
+	result.elements[0][2] = (matrix->elements[0][1] * matrix->elements[1][2] - matrix->elements[0][2] * matrix->elements[1][1]) / det;
+	result.elements[1][0] = (matrix->elements[1][2] * matrix->elements[2][0] - matrix->elements[1][0] * matrix->elements[2][2]) / det;
+	result.elements[1][1] = (matrix->elements[0][0] * matrix->elements[2][2] - matrix->elements[0][2] * matrix->elements[2][0]) / det;
+	result.elements[1][2] = (matrix->elements[0][2] * matrix->elements[1][0] - matrix->elements[0][0] * matrix->elements[1][2]) / det;
+	result.elements[2][0] = (matrix->elements[1][0] * matrix->elements[2][1] - matrix->elements[1][1] * matrix->elements[2][0]) / det;
+	result.elements[2][1] = (matrix->elements[0][1] * matrix->elements[2][0] - matrix->elements[0][0] * matrix->elements[2][1]) / det;
+	result.elements[2][2] = (matrix->elements[0][0] * matrix->elements[1][1] - matrix->elements[0][1] * matrix->elements[1][0]) / det;
+
+	return result;
+}
+
+bool wlf_matrix3x3_equal(const struct wlf_matrix3x3 *a, const struct wlf_matrix3x3 *b) {
+	for (int i = 0; i < 3; i++) {
+		for (int j = 0; j < 3; j++) {
+			if (a->elements[i][j] != b->elements[i][j]) {
+				return false;
+			}
+		}
+	}
+
+	return true;
+}
+
+bool wlf_matrix3x3_nearly_equal(const struct wlf_matrix3x3 *a, const struct wlf_matrix3x3 *b, double epsilon) {
+	for (int i = 0; i < 3; i++) {
+		for (int j = 0; j < 3; j++) {
+			if (fabs(a->elements[i][j] - b->elements[i][j]) > epsilon) {
+				return false;
+			}
+		}
+	}
+
+	return true;
+}

--- a/math/wlf_matrix4x4.c
+++ b/math/wlf_matrix4x4.c
@@ -1,0 +1,225 @@
+#include "wlf/math/wlf_matrix4x4.h"
+#include "wlf/utils/wlf_log.h"
+
+#include <stdlib.h>
+#include <stdio.h>
+#include <string.h>
+#include <math.h>
+
+#define WLF_MATRIX4x4_STRLEN 256
+
+struct wlf_matrix4x4 wlf_matrix4x4_create_zero(void) {
+	struct wlf_matrix4x4 matrix = {0};
+
+	return matrix;
+}
+
+struct wlf_matrix4x4 wlf_matrix4x4_identity(void) {
+	struct wlf_matrix4x4 matrix = {0};
+	matrix.elements[0][0] = 1.0;
+	matrix.elements[1][1] = 1.0;
+	matrix.elements[2][2] = 1.0;
+	matrix.elements[3][3] = 1.0;
+
+	return matrix;
+}
+
+char* wlf_matrix4x4_to_str(const struct wlf_matrix4x4 *matrix) {
+	if (matrix == NULL) {
+		return strdup("(NULL)");
+	}
+
+	char *buffer = malloc(WLF_MATRIX4x4_STRLEN);
+	if (buffer == NULL) {
+		wlf_log(WLF_ERROR, "Memory allocation failed for wlf_matrix4x4_to_str");
+		return NULL;
+	}
+
+	snprintf(buffer, WLF_MATRIX4x4_STRLEN,
+			"[[%.3f, %.3f, %.3f, %.3f],\n"
+			" [%.3f, %.3f, %.3f, %.3f],\n"
+			" [%.3f, %.3f, %.3f, %.3f],\n"
+			" [%.3f, %.3f, %.3f, %.3f]]",
+			matrix->elements[0][0], matrix->elements[0][1], matrix->elements[0][2], matrix->elements[0][3],
+			matrix->elements[1][0], matrix->elements[1][1], matrix->elements[1][2], matrix->elements[1][3],
+			matrix->elements[2][0], matrix->elements[2][1], matrix->elements[2][2], matrix->elements[2][3],
+			matrix->elements[3][0], matrix->elements[3][1], matrix->elements[3][2], matrix->elements[3][3]);
+
+	return buffer;
+}
+
+double wlf_matrix4x4_get(const struct wlf_matrix4x4 *matrix, int row, int col) {
+	return matrix->elements[row][col];
+}
+
+void wlf_matrix4x4_set(struct wlf_matrix4x4 *matrix, int row, int col, double value) {
+	matrix->elements[row][col] = value;
+}
+
+struct wlf_matrix4x4 wlf_matrix4x4_add(const struct wlf_matrix4x4 *a, const struct wlf_matrix4x4 *b) {
+	struct wlf_matrix4x4 result = {0};
+	for (int i = 0; i < 4; i++) {
+		for (int j = 0; j < 4; j++) {
+			result.elements[i][j] = a->elements[i][j] + b->elements[i][j];
+		}
+	}
+
+	return result;
+}
+
+struct wlf_matrix4x4 wlf_matrix4x4_subtract(const struct wlf_matrix4x4 *a, const struct wlf_matrix4x4 *b) {
+	struct wlf_matrix4x4 result = {0};
+	for (int i = 0; i < 4; i++) {
+		for (int j = 0; j < 4; j++) {
+			result.elements[i][j] = a->elements[i][j] - b->elements[i][j];
+		}
+	}
+
+	return result;
+}
+
+struct wlf_matrix4x4 wlf_matrix4x4_multiply_scalar(const struct wlf_matrix4x4 *matrix, double scalar) {
+	struct wlf_matrix4x4 result = {0};
+	for (int i = 0; i < 4; i++) {
+		for (int j = 0; j < 4; j++) {
+			result.elements[i][j] = matrix->elements[i][j] * scalar;
+		}
+	}
+
+	return result;
+}
+
+struct wlf_matrix4x4 wlf_matrix4x4_multiply(const struct wlf_matrix4x4 *a, const struct wlf_matrix4x4 *b) {
+	struct wlf_matrix4x4 result = {0};
+	for (int i = 0; i < 4; i++) {
+		for (int j = 0; j < 4; j++) {
+			for (int k = 0; k < 4; k++) {
+				result.elements[i][j] += a->elements[i][k] * b->elements[k][j];
+			}
+		}
+	}
+
+	return result;
+}
+
+struct wlf_matrix4x4 wlf_matrix4x4_transpose(const struct wlf_matrix4x4 *matrix) {
+	struct wlf_matrix4x4 result = {0};
+	for (int i = 0; i < 4; i++) {
+		for (int j = 0; j < 4; j++) {
+			result.elements[j][i] = matrix->elements[i][j];
+		}
+	}
+
+	return result;
+}
+
+double wlf_matrix4x4_determinant(const struct wlf_matrix4x4 *matrix) {
+	double det = 0.0;
+	for (int i = 0; i < 4; i++) {
+		det += (matrix->elements[0][i] *
+				(matrix->elements[1][(i+1)%4] * matrix->elements[2][(i+2)%4] * matrix->elements[3][(i+3)%4] -
+				matrix->elements[1][(i+2)%4] * matrix->elements[2][(i+1)%4] * matrix->elements[3][(i+3)%4]));
+	}
+
+	return det;
+}
+
+struct wlf_matrix4x4 wlf_matrix4x4_inverse(const struct wlf_matrix4x4 *matrix) {
+	struct wlf_matrix4x4 result = {0};
+	double det = wlf_matrix4x4_determinant(matrix);
+
+	if (det == 0) {
+		// The matrix is not invertible, return a zero matrix
+		return result;
+	}
+
+	result.elements[0][0] = (matrix->elements[1][1] * (matrix->elements[2][2] * matrix->elements[3][3] - matrix->elements[2][3] * matrix->elements[3][2]) -
+								matrix->elements[1][2] * (matrix->elements[2][1] * matrix->elements[3][3] - matrix->elements[2][3] * matrix->elements[3][1]) +
+								matrix->elements[1][3] * (matrix->elements[2][1] * matrix->elements[3][2] - matrix->elements[2][2] * matrix->elements[3][1])) / det;
+
+	result.elements[0][1] = -(matrix->elements[1][0] * (matrix->elements[2][2] * matrix->elements[3][3] - matrix->elements[2][3] * matrix->elements[3][2]) -
+								matrix->elements[1][2] * (matrix->elements[2][0] * matrix->elements[3][3] - matrix->elements[2][3] * matrix->elements[3][0]) +
+								matrix->elements[1][3] * (matrix->elements[2][0] * matrix->elements[3][2] - matrix->elements[2][2] * matrix->elements[3][0])) / det;
+
+	result.elements[0][2] = (matrix->elements[1][0] * (matrix->elements[2][1] * matrix->elements[3][3] - matrix->elements[2][3] * matrix->elements[3][1]) -
+								matrix->elements[1][1] * (matrix->elements[2][0] * matrix->elements[3][3] - matrix->elements[2][3] * matrix->elements[3][0]) +
+								matrix->elements[1][3] * (matrix->elements[2][0] * matrix->elements[3][1] - matrix->elements[2][1] * matrix->elements[3][0])) / det;
+
+	result.elements[0][3] = -(matrix->elements[1][0] * (matrix->elements[2][1] * matrix->elements[3][2] - matrix->elements[2][2] * matrix->elements[3][1]) -
+								matrix->elements[1][1] * (matrix->elements[2][0] * matrix->elements[3][2] - matrix->elements[2][2] * matrix->elements[3][0]) +
+								matrix->elements[1][2] * (matrix->elements[2][0] * matrix->elements[3][1] - matrix->elements[2][1] * matrix->elements[3][0])) / det;
+
+	result.elements[1][0] = -(matrix->elements[0][1] * (matrix->elements[2][2] * matrix->elements[3][3] - matrix->elements[2][3] * matrix->elements[3][2]) -
+								matrix->elements[0][2] * (matrix->elements[2][1] * matrix->elements[3][3] - matrix->elements[2][3] * matrix->elements[3][1]) +
+								matrix->elements[0][3] * (matrix->elements[2][1] * matrix->elements[3][2] - matrix->elements[2][2] * matrix->elements[3][1])) / det;
+
+	result.elements[1][1] = (matrix->elements[0][0] * (matrix->elements[2][2] * matrix->elements[3][3] - matrix->elements[2][3] * matrix->elements[3][2]) -
+								matrix->elements[0][2] * (matrix->elements[2][0] * matrix->elements[3][3] - matrix->elements[2][3] * matrix->elements[3][0]) +
+								matrix->elements[0][3] * (matrix->elements[2][0] * matrix->elements[3][2] - matrix->elements[2][2] * matrix->elements[3][0])) / det;
+
+	result.elements[1][2] = -(matrix->elements[0][0] * (matrix->elements[2][1] * matrix->elements[3][3] - matrix->elements[2][3] * matrix->elements[3][1]) -
+								matrix->elements[0][1] * (matrix->elements[2][0] * matrix->elements[3][3] - matrix->elements[2][3] * matrix->elements[3][0]) +
+								matrix->elements[0][3] * (matrix->elements[2][0] * matrix->elements[3][1] - matrix->elements[2][1] * matrix->elements[3][0])) / det;
+
+	result.elements[1][3] = (matrix->elements[0][0] * (matrix->elements[2][1] * matrix->elements[3][2] - matrix->elements[2][2] * matrix->elements[3][1]) -
+								matrix->elements[0][1] * (matrix->elements[2][0] * matrix->elements[3][2] - matrix->elements[2][2] * matrix->elements[3][0]) +
+								matrix->elements[0][2] * (matrix->elements[2][0] * matrix->elements[3][1] - matrix->elements[2][1] * matrix->elements[3][0])) / det;
+
+	result.elements[2][0] = (matrix->elements[0][1] * (matrix->elements[1][2] * matrix->elements[3][3] - matrix->elements[1][3] * matrix->elements[3][2]) -
+								matrix->elements[0][2] * (matrix->elements[1][1] * matrix->elements[3][3] - matrix->elements[1][3] * matrix->elements[3][1]) +
+								matrix->elements[0][3] * (matrix->elements[1][1] * matrix->elements[3][2] - matrix->elements[1][2] * matrix->elements[3][1])) / det;
+
+	result.elements[2][1] = -(matrix->elements[0][0] * (matrix->elements[1][2] * matrix->elements[3][3] - matrix->elements[1][3] * matrix->elements[3][2]) -
+								matrix->elements[0][2] * (matrix->elements[1][0] * matrix->elements[3][3] - matrix->elements[1][3] * matrix->elements[3][0]) +
+								matrix->elements[0][3] * (matrix->elements[1][0] * matrix->elements[3][2] - matrix->elements[1][2] * matrix->elements[3][0])) / det;
+
+	result.elements[2][2] = (matrix->elements[0][0] * (matrix->elements[1][1] * matrix->elements[3][3] - matrix->elements[1][3] * matrix->elements[3][1]) -
+								matrix->elements[0][1] * (matrix->elements[1][0] * matrix->elements[3][3] - matrix->elements[1][3] * matrix->elements[3][0]) +
+								matrix->elements[0][3] * (matrix->elements[1][0] * matrix->elements[3][1] - matrix->elements[1][1] * matrix->elements[3][0])) / det;
+
+	result.elements[2][3] = -(matrix->elements[0][0] * (matrix->elements[1][1] * matrix->elements[3][2] - matrix->elements[1][2] * matrix->elements[3][1]) -
+								matrix->elements[0][1] * (matrix->elements[1][0] * matrix->elements[3][2] - matrix->elements[1][2] * matrix->elements[3][0]) +
+								matrix->elements[0][2] * (matrix->elements[1][0] * matrix->elements[3][1] - matrix->elements[1][1] * matrix->elements[3][0])) / det;
+
+	result.elements[3][0] = -(matrix->elements[0][1] * (matrix->elements[1][2] * matrix->elements[2][3] - matrix->elements[1][3] * matrix->elements[2][2]) -
+								matrix->elements[0][2] * (matrix->elements[1][1] * matrix->elements[2][3] - matrix->elements[1][3] * matrix->elements[2][1]) +
+								matrix->elements[0][3] * (matrix->elements[1][1] * matrix->elements[2][2] - matrix->elements[1][2] * matrix->elements[2][1])) / det;
+
+	result.elements[3][1] = (matrix->elements[0][0] * (matrix->elements[1][2] * matrix->elements[2][3] - matrix->elements[1][3] * matrix->elements[2][2]) -
+								matrix->elements[0][2] * (matrix->elements[1][0] * matrix->elements[2][3] - matrix->elements[1][3] * matrix->elements[2][0]) +
+								matrix->elements[0][3] * (matrix->elements[1][0] * matrix->elements[2][2] - matrix->elements[1][2] * matrix->elements[2][0])) / det;
+
+	result.elements[3][2] = -(matrix->elements[0][0] * (matrix->elements[1][1] * matrix->elements[2][3] - matrix->elements[1][3] * matrix->elements[2][1]) -
+								matrix->elements[0][1] * (matrix->elements[1][0] * matrix->elements[2][3] - matrix->elements[1][3] * matrix->elements[2][0]) +
+								matrix->elements[0][3] * (matrix->elements[1][0] * matrix->elements[2][1] - matrix->elements[1][1] * matrix->elements[2][0])) / det;
+
+	result.elements[3][3] = (matrix->elements[0][0] * (matrix->elements[1][1] * matrix->elements[2][2] - matrix->elements[1][2] * matrix->elements[2][1]) -
+								matrix->elements[0][1] * (matrix->elements[1][0] * matrix->elements[2][2] - matrix->elements[1][2] * matrix->elements[2][0]) +
+								matrix->elements[0][2] * (matrix->elements[1][0] * matrix->elements[2][1] - matrix->elements[1][1] * matrix->elements[2][0])) / det;
+
+	return result;
+}
+
+bool wlf_matrix4x4_equal(const struct wlf_matrix4x4 *a, const struct wlf_matrix4x4 *b) {
+	for (int i = 0; i < 4; i++) {
+		for (int j = 0; j < 4; j++) {
+			if (a->elements[i][j] != b->elements[i][j]) {
+				return false;
+			}
+		}
+	}
+
+	return true;
+}
+
+bool wlf_matrix4x4_nearly_equal(const struct wlf_matrix4x4 *a, const struct wlf_matrix4x4 *b, double epsilon) {
+	for (int i = 0; i < 4; i++) {
+		for (int j = 0; j < 4; j++) {
+			if (fabs(a->elements[i][j] - b->elements[i][j]) > epsilon) {
+				return false;
+			}
+		}
+	}
+
+	return true;
+}

--- a/math/wlf_point.c
+++ b/math/wlf_point.c
@@ -1,0 +1,107 @@
+#include "wlf/math/wlf_point.h"
+#include "wlf/utils/wlf_log.h"
+
+#include <stdlib.h>
+#include <stdio.h>
+#include <math.h>
+#include <string.h>
+
+#define WLF_POINT_STRLEN 32
+
+char *wlf_point_to_str(const struct wlf_point *point) {
+	if (point == NULL) {
+		return strdup("(NULL)");
+	}
+
+	char *buffer = malloc(WLF_POINT_STRLEN);
+	if (buffer == NULL) {
+		wlf_log(WLF_ERROR, "Memory allocation failed for wlf_point_to_str");
+		return NULL;
+	}
+
+	snprintf(buffer, WLF_POINT_STRLEN, "(%d, %d)", point->x, point->y);
+
+	return buffer;
+}
+
+bool wlf_point_equal(const struct wlf_point *a, const struct wlf_point *b) {
+	return (a->x == b->x) && (a->y == b->y);
+}
+
+bool wlf_point_is_zero(const struct wlf_point *p) {
+	return (p->x == 0) && (p->y == 0);
+}
+
+struct wlf_point wlf_point_add(const struct wlf_point *a, const struct wlf_point *b) {
+	return (struct wlf_point){.x = a->x + b->x, .y = a->y + b->y};
+}
+
+struct wlf_point wlf_point_subtract(const struct wlf_point *a, const struct wlf_point *b) {
+	return (struct wlf_point){.x = a->x - b->x, .y = a->y - b->y};
+}
+
+struct wlf_point wlf_point_multiply(const struct wlf_point *p, double scalar) {
+	return (struct wlf_point){.x = (int)round(p->x * scalar), .y = (int)round(p->y * scalar)};
+}
+
+int wlf_point_manhattan_distance(const struct wlf_point *p1, const struct wlf_point *p2) {
+	return abs(p1->x - p2->x) + abs(p1->y - p2->y);
+}
+
+double wlf_point_euclidean_distance(const struct wlf_point *p1, const struct wlf_point *p2) {
+	return sqrt(pow(p1->x - p2->x, 2) + pow(p1->y - p2->y, 2));
+}
+
+bool wlf_point_from_str(const char *str, struct wlf_point *point) {
+	if (str == NULL || point == NULL) {
+		return false;
+	}
+
+	while (*str == ' ' || *str == '\t') {
+		str++;
+	}
+
+	if (*str != '(') {
+		return false;
+	}
+	str++;
+
+	char *endptr;
+	long x = strtol(str, &endptr, 10);
+	if (endptr == str) {
+		return false;
+	}
+	str = endptr;
+
+	while (*str == ' ' || *str == '\t') {
+		str++;
+	}
+
+	if (*str != ',') {
+		return false;
+	}
+	str++;
+
+	while (*str == ' ' || *str == '\t') {
+		str++;
+	}
+
+	long y = strtol(str, &endptr, 10);
+	if (endptr == str) {
+		return false;
+	}
+	str = endptr;
+
+	while (*str == ' ' || *str == '\t') {
+		str++;
+	}
+
+	if (*str != ')') {
+		return false;
+	}
+
+	point->x = (int)x;
+	point->y = (int)y;
+
+	return true;
+}

--- a/math/wlf_quaternion.c
+++ b/math/wlf_quaternion.c
@@ -1,0 +1,100 @@
+#include "wlf/math/wlf_quaternion.h"
+#include "wlf/utils/wlf_log.h"
+
+#include <stdlib.h>
+#include <stdio.h>
+#include <string.h>
+#include <math.h>
+#include <assert.h>
+
+#define WLF_QUATERNION_STRLEN 256
+
+struct wlf_quaternion wlf_quaternion_make(double w, double x, double y, double z) {
+	struct wlf_quaternion q = {w, x, y, z};
+	return q;
+}
+
+char* wlf_quaternion_to_str(const struct wlf_quaternion *quaternion) {
+	return wlf_quaternion_to_str_prec(quaternion, 3);
+}
+
+char* wlf_quaternion_to_str_prec(const struct wlf_quaternion *quaternion, uint8_t precision) {
+
+	if (quaternion == NULL) {
+		return strdup("[NULL]");
+	}
+
+	if (precision > 15) {
+		precision = 15;
+	}
+
+	char fmt[64];
+	snprintf(fmt, sizeof(fmt), "[%%.%df, %%.%df, %%.%df, %%.%df]",
+		precision, precision, precision, precision);
+
+	char *buffer = malloc(WLF_QUATERNION_STRLEN);
+	if (buffer == NULL) {
+		wlf_log(WLF_ERROR, "Memory allocation failed for wlf_quaternion_to_str_prec");
+		return NULL;
+	}
+
+	snprintf(buffer, WLF_QUATERNION_STRLEN, fmt, quaternion->w, quaternion->x, quaternion->y, quaternion->z);
+
+	return buffer;
+}
+
+struct wlf_quaternion wlf_quaternion_add(const struct wlf_quaternion *a, const struct wlf_quaternion *b) {
+	return wlf_quaternion_make(a->w + b->w, a->x + b->x, a->y + b->y, a->z + b->z);
+}
+
+struct wlf_quaternion wlf_quaternion_subtract(const struct wlf_quaternion *a, const struct wlf_quaternion *b) {
+	return wlf_quaternion_make(a->w - b->w, a->x - b->x, a->y - b->y, a->z - b->z);
+}
+
+struct wlf_quaternion wlf_quaternion_multiply(const struct wlf_quaternion *a, const struct wlf_quaternion *b) {
+	return wlf_quaternion_make(
+				a->w * b->w - a->x * b->x - a->y * b->y - a->z * b->z,
+				a->w * b->x + a->x * b->w + a->y * b->z - a->z * b->y,
+				a->w * b->y - a->x * b->z + a->y * b->w + a->z * b->x,
+				a->w * b->z + a->x * b->y - a->y * b->x + a->z * b->w
+	);
+}
+
+struct wlf_quaternion wlf_quaternion_conjugate(const struct wlf_quaternion *q) {
+	return wlf_quaternion_make(q->w, -q->x, -q->y, -q->z);
+}
+
+double wlf_quaternion_norm(const struct wlf_quaternion *q) {
+	return sqrt(q->w * q->w + q->x * q->x + q->y * q->y + q->z * q->z);
+}
+
+struct wlf_quaternion wlf_quaternion_normalize(const struct wlf_quaternion *q) {
+	double norm = wlf_quaternion_norm(q);
+	if (norm == 0) {
+		// Return identity if norm is zero
+		return WLF_QUATERNION_IDENTITY;
+	}
+
+	return wlf_quaternion_make(q->w / norm, q->x / norm, q->y / norm, q->z / norm);
+}
+
+struct wlf_quaternion wlf_quaternion_inverse(const struct wlf_quaternion *q) {
+	double norm = wlf_quaternion_norm(q);
+	if (norm == 0) {
+		// Return identity if norm is zero
+		return WLF_QUATERNION_IDENTITY;
+	}
+	double norm_squared = norm * norm;
+	struct wlf_quaternion conjugate = wlf_quaternion_conjugate(q);
+	return wlf_quaternion_make(conjugate.w / norm_squared, conjugate.x / norm_squared,
+				conjugate.y / norm_squared, conjugate.z / norm_squared);
+}
+
+bool wlf_quaternion_equal(const struct wlf_quaternion *a, const struct wlf_quaternion *b) {
+	return (a->w == b->w) && (a->x == b->x) && (a->y == b->y) && (a->z == b->z);
+}
+
+bool wlf_quaternion_nearly_equal(const struct wlf_quaternion *a, const struct wlf_quaternion *b, double epsilon) {
+	return (fabs(a->w - b->w) < epsilon) && (fabs(a->x - b->x) < epsilon) &&
+			(fabs(a->y - b->y) < epsilon) && (fabs(a->z - b->z) < epsilon);
+}

--- a/math/wlf_ray2.c
+++ b/math/wlf_ray2.c
@@ -1,0 +1,59 @@
+#include "wlf/math/wlf_ray2.h"
+#include "wlf/utils/wlf_log.h"
+
+#include <stdlib.h>
+#include <stdio.h>
+#include <string.h>
+
+#define WLF_RAY2_STRLEN 256
+
+struct wlf_ray2 wlf_ray2_make(struct wlf_vector2 origin, struct wlf_vector2 direction) {
+	struct wlf_ray2 ray = {origin, direction};
+	return ray;
+}
+
+char* wlf_ray2_to_str(const struct wlf_ray2 *ray) {
+	if (ray == NULL) {
+		return strdup("(NULL)");
+	}
+
+	char *buffer = malloc(WLF_RAY2_STRLEN);
+	if (buffer == NULL) {
+		wlf_log(WLF_ERROR, "Memory allocation failed for wlf_ray2_to_str");
+		return NULL;
+	}
+
+	char *origin_str = wlf_vector2_to_str(&ray->origin);
+	char *direction_str = wlf_vector2_to_str(&ray->direction);
+
+	if (origin_str && direction_str) {
+		snprintf(buffer, WLF_RAY2_STRLEN, "(Origin: %s, Direction: %s)",
+				origin_str, direction_str);
+	} else {
+		free(origin_str);
+		free(direction_str);
+		return strdup("(NULL)");
+	}
+
+	free(origin_str);
+	free(direction_str);
+
+	return buffer;
+}
+
+struct wlf_vector2 wlf_ray2_point_at_parameter(const struct wlf_ray2 *ray, double t) {
+	return (struct wlf_vector2) {
+			.u = ray->origin.u + t * ray->direction.u,
+			.v = ray->origin.v + t * ray->direction.v,
+		};
+}
+
+bool wlf_ray2_equal(const struct wlf_ray2 *a, const struct wlf_ray2 *b) {
+	return wlf_vector2_equal(&a->origin, &b->origin) &&
+			wlf_vector2_equal(&a->direction, &b->direction);
+}
+
+bool wlf_ray2_nearly_equal(const struct wlf_ray2 *a, const struct wlf_ray2 *b, double epsilon) {
+	return wlf_vector2_nearly_equal(&a->origin, &b->origin, epsilon) &&
+			wlf_vector2_nearly_equal(&a->direction, &b->direction, epsilon);
+}

--- a/math/wlf_ray3.c
+++ b/math/wlf_ray3.c
@@ -1,0 +1,60 @@
+#include "wlf/math/wlf_ray3.h"
+#include "wlf/utils/wlf_log.h"
+
+#include <stdlib.h>
+#include <stdio.h>
+#include <string.h>
+
+#define WLF_RAY3_STRLEN 384
+
+struct wlf_ray3 wlf_ray3_make(struct wlf_vector3 origin, struct wlf_vector3 direction) {
+	struct wlf_ray3 ray = {origin, direction};
+	return ray;
+}
+
+char* wlf_ray3_to_str(const struct wlf_ray3 *ray) {
+	if (ray == NULL) {
+		return strdup("(NULL)");
+	}
+
+	char *buffer = malloc(WLF_RAY3_STRLEN);
+	if (buffer == NULL) {
+		wlf_log(WLF_ERROR, "Memory allocation failed for wlf_ray3_to_str");
+		return NULL;
+	}
+
+	char *origin_str = wlf_vector3_to_str(&ray->origin);
+	char *direction_str = wlf_vector3_to_str(&ray->direction);
+
+	if (origin_str && direction_str) {
+		snprintf(buffer, WLF_RAY3_STRLEN, "(Origin: %s, Direction: %s)",
+				origin_str, direction_str);
+	} else {
+		free(origin_str);
+		free(direction_str);
+		return strdup("(NULL)");
+	}
+
+	free(origin_str);
+	free(direction_str);
+
+	return buffer;
+}
+
+struct wlf_vector3 wlf_ray3_point_at_parameter(const struct wlf_ray3 *ray, double t) {
+	return (struct wlf_vector3) {
+			.x = ray->origin.x + t * ray->direction.x,
+			.y = ray->origin.y + t * ray->direction.y,
+			.z = ray->origin.z + t * ray->direction.z,
+		};
+}
+
+bool wlf_ray3_equal(const struct wlf_ray3 *a, const struct wlf_ray3 *b) {
+	return wlf_vector3_equal(&a->origin, &b->origin) &&
+			wlf_vector3_equal(&a->direction, &b->direction);
+}
+
+bool wlf_ray3_nearly_equal(const struct wlf_ray3 *a, const struct wlf_ray3 *b, double epsilon) {
+	return wlf_vector3_nearly_equal(&a->origin, &b->origin, epsilon) &&
+			wlf_vector3_nearly_equal(&a->direction, &b->direction, epsilon);
+}

--- a/math/wlf_rect.c
+++ b/math/wlf_rect.c
@@ -1,0 +1,214 @@
+#include "wlf/math/wlf_rect.h"
+#include "wlf/math/wlf_point.h"
+#include "wlf/math/wlf_size.h"
+#include "wlf/utils/wlf_log.h"
+
+#include <stdlib.h>
+#include <stdio.h>
+#include <math.h>
+#include <string.h>
+
+#define WLF_RECT_STRLEN 64
+
+struct wlf_rect wlf_rect_make(int x, int y, int width, int height) {
+	struct wlf_rect rect = {
+		.x = x,
+		.y = y,
+		.width = width,
+		.height = height,
+	};
+
+	return rect;
+}
+
+char* wlf_rect_to_str(const struct wlf_rect *rect) {
+	if (rect == NULL) {
+		return strdup("(NULL)");
+	}
+
+	char *buffer = malloc(WLF_RECT_STRLEN);
+	if (buffer == NULL) {
+		wlf_log(WLF_ERROR, "Memory allocation failed for wlf_rect_to_str");
+		return NULL;
+	}
+
+	snprintf(buffer, WLF_RECT_STRLEN, "(%d, %d, %d, %d)", rect->x, rect->y, rect->width, rect->height);
+
+	return buffer;
+}
+
+struct wlf_rect wlf_rect_from_point_size(const struct wlf_point *pos, const struct wlf_size *size) {
+	return wlf_rect_make(pos->x, pos->y, size->width, size->height);
+}
+
+struct wlf_rect wlf_rect_from_points(const struct wlf_point *p1, const struct wlf_point *p2) {
+	int x = fmin(p1->x, p2->x);
+	int y = fmin(p1->y, p2->y);
+	int width = abs(p1->x - p2->x);
+	int height = abs(p1->y - p2->y);
+
+	return wlf_rect_make(x, y, width, height);
+}
+
+bool wlf_rect_equal(const struct wlf_rect *a, const struct wlf_rect *b) {
+	return (a->x == b->x) && (a->y == b->y) && (a->width == b->width) && (a->height == b->height);
+}
+
+bool wlf_rect_is_empty(const struct wlf_rect *rect) {
+	return (rect->width == 0) || (rect->height == 0);
+}
+
+bool wlf_rect_is_valid(const struct wlf_rect *rect) {
+	return (rect->width > 0) && (rect->height > 0);
+}
+
+struct wlf_point wlf_rect_get_position(const struct wlf_rect *rect) {
+	return (struct wlf_point){.x = rect->x, .y = rect->y};
+}
+
+struct wlf_size wlf_rect_get_size(const struct wlf_rect *rect) {
+	return (struct wlf_size){.width = rect->width, .height = rect->height};
+}
+
+struct wlf_point wlf_rect_get_center(const struct wlf_rect *rect) {
+	return (struct wlf_point){
+		.x = rect->x + rect->width / 2,
+		.y = rect->y + rect->height / 2
+	};
+}
+
+struct wlf_point wlf_rect_get_top_left(const struct wlf_rect *rect) {
+	return (struct wlf_point){
+		.x = rect->x,
+		.y = rect->y
+	};
+}
+
+struct wlf_point wlf_rect_get_bottom_right(const struct wlf_rect *rect) {
+	return (struct wlf_point){
+		.x = rect->x + rect->width,
+		.y = rect->y + rect->height
+	};
+}
+
+int wlf_rect_area(const struct wlf_rect *rect) {
+	return rect->width * rect->height;
+}
+
+int wlf_rect_perimeter(const struct wlf_rect *rect) {
+	return 2 * (rect->width + rect->height);
+}
+
+struct wlf_rect wlf_rect_offset(const struct wlf_rect *rect, const struct wlf_point *offset) {
+	return wlf_rect_make(rect->x + offset->x, rect->y + offset->y, rect->width, rect->height);
+}
+
+struct wlf_rect wlf_rect_inflate(const struct wlf_rect *rect, int dx, int dy) {
+	return wlf_rect_make(rect->x - dx, rect->y - dy, rect->width + 2 * dx, rect->height + 2 * dy);
+}
+
+struct wlf_rect wlf_rect_scale(const struct wlf_rect *rect, double sx, double sy) {
+	return wlf_rect_make(rect->x, rect->y, (int)(rect->width * sx), (int)(rect->height * sy));
+}
+
+bool wlf_rect_contains_point_d(const struct wlf_rect *rect, double x, double y) {
+	return (x >= rect->x) && (x <= rect->x + rect->width) &&
+			(y >= rect->y) && (y <= rect->y + rect->height);
+}
+
+bool wlf_rect_contains_point(const struct wlf_rect *rect, const struct wlf_point *point) {
+	return (point->x >= rect->x) && (point->x <= rect->x + rect->width) &&
+			(point->y >= rect->y) && (point->y <= rect->y + rect->height);
+}
+
+bool wlf_rect_contains_rect(const struct wlf_rect *outer, const struct wlf_rect *inner) {
+	struct wlf_point top_left = wlf_rect_get_top_left(inner);
+	struct wlf_point bottom_right = wlf_rect_get_bottom_right(inner);
+
+	return wlf_rect_contains_point(outer, &top_left) &&
+			wlf_rect_contains_point(outer, &bottom_right);
+}
+
+bool wlf_rect_intersects(const struct wlf_rect *a, const struct wlf_rect *b) {
+	return !(a->x + a->width < b->x || a->x > b->x + b->width ||
+			a->y + a->height < b->y || a->y > b->y + b->height);
+}
+
+struct wlf_rect wlf_rect_intersection(const struct wlf_rect *a, const struct wlf_rect *b) {
+	// Return zero rectangle if no intersection
+	if (!wlf_rect_intersects(a, b)) {
+		return WLF_RECT_ZERO;
+	}
+
+	int x1 = fmax(a->x, b->x);
+	int y1 = fmax(a->y, b->y);
+	int x2 = fmin(a->x + a->width, b->x + b->width);
+	int y2 = fmin(a->y + a->height, b->y + b->height);
+
+	return wlf_rect_make(x1, y1, x2 - x1, y2 - y1);
+}
+
+struct wlf_rect wlf_rect_union(const struct wlf_rect *a, const struct wlf_rect *b) {
+	int x1 = fmin(a->x, b->x);
+	int y1 = fmin(a->y, b->y);
+	int x2 = fmax(a->x + a->width, b->x + b->width);
+	int y2 = fmax(a->y + a->height, b->y + b->height);
+
+	return wlf_rect_make(x1, y1, x2 - x1, y2 - y1);
+}
+
+bool wlf_rect_from_str(const char *str, struct wlf_rect *rect) {
+	if (str == NULL || rect == NULL) {
+		return false;
+	}
+
+	while (*str == ' ' || *str == '\t' || *str == '\n' || *str == '\r') {
+		str++;
+	}
+
+	if (*str == '\0') {
+		return false;
+	}
+
+	if (*str != '(') {
+		return false;
+	}
+	str++;
+
+	int x, y, width, height;
+	int parsed = sscanf(str, "%d,%d,%d,%d", &x, &y, &width, &height);
+
+	if (parsed != 4) {
+		parsed = sscanf(str, "%d, %d, %d, %d", &x, &y, &width, &height);
+	}
+
+	if (parsed != 4) {
+		return false;
+	}
+
+	char *end_ptr = strchr(str, ')');
+	if (end_ptr == NULL) {
+		return false;
+	}
+
+	char *check_ptr = end_ptr - 1;
+	while (check_ptr > str && (*check_ptr == ' ' || *check_ptr == '\t')) {
+		check_ptr--;
+	}
+
+	end_ptr++;
+	while (*end_ptr == ' ' || *end_ptr == '\t' || *end_ptr == '\n' || *end_ptr == '\r') {
+		end_ptr++;
+	}
+
+	if (*end_ptr != '\0') {
+		return false;
+	}
+
+	rect->x = x;
+	rect->y = y;
+	rect->width = width;
+	rect->height = height;
+
+	return true;
+}

--- a/math/wlf_region.c
+++ b/math/wlf_region.c
@@ -1,0 +1,307 @@
+#include "wlf/math/wlf_region.h"
+#include "wlf/utils/wlf_log.h"
+
+#include <stdlib.h>
+#include <string.h>
+#include <limits.h>
+
+static struct wlf_frect rect_union(const struct wlf_frect *a, const struct wlf_frect *b) {
+	if (a == NULL) {
+		return b ? *b : (struct wlf_frect){
+			.x = 0,
+			.y = 0,
+			.width = 0,
+			.height= 0,
+		};
+	}
+
+	if (b == NULL) {
+		return *a;
+	}
+
+	double x1 = (a->x < b->x) ? a->x : b->x;
+	double y1 = (a->y < b->y) ? a->y : b->y;
+	double x2 = ((a->x + a->width) > (b->x + b->width)) ? (a->x + a->width) : (b->x + b->width);
+	double y2 = ((a->y + a->height) > (b->y + b->height)) ? (a->y + a->height) : (b->y + b->height);
+
+	struct wlf_frect out;
+	out.x = x1;
+	out.y = y1;
+	out.width = x2 - x1;
+	out.height = y2 - y1;
+
+	return out;
+}
+
+void wlf_region_init(struct wlf_region *region) {
+	region->data = malloc(sizeof(struct wlf_region_data));
+	if (region->data) {
+		region->data->size = 4;
+		region->data->numRects = 0;
+		region->data->rects = calloc(region->data->size, sizeof(struct wlf_frect));
+		if (region->data->rects == NULL) {
+			wlf_log(WLF_ERROR, "Failed to allocate memory for wlf_region_data rects");
+			free(region->data);
+			region->data = NULL;
+			return;
+		}
+	} else {
+		wlf_log(WLF_ERROR, "Failed to allocate memory for wlf_region_data");
+	}
+
+	region->extents = (struct wlf_frect){
+		.x= 0,
+		.y = 0,
+		.width = 0,
+		.height = 0,
+	};
+}
+
+void wlf_region_fini(struct wlf_region *region) {
+	if (region == NULL) {
+		return;
+	}
+
+	if (region->data == NULL) {
+		return;
+	}
+
+	free(region->data->rects);
+	free(region->data);
+	region->data = NULL;
+}
+
+char* wlf_region_to_str(const struct wlf_region *region) {
+	if (region == NULL || region->data == NULL) {
+		return strdup("{NULL}");
+	}
+
+	size_t str_size = 256 + region->data->numRects * 64;
+	char *str = malloc(str_size);
+	if (!str) {
+		wlf_log(WLF_ERROR, "Failed to allocate memory for region string representation");
+		return NULL;
+	}
+
+	int offset = snprintf(str, str_size, "{\n");
+
+	for (long i = 0; i < region->data->numRects; ++i) {
+		const struct wlf_frect *r = &region->data->rects[i];
+		int written = snprintf(str + offset, str_size - offset,
+			"[%.3f,%.3f,%.3f,%.3f]", r->x, r->y, r->width, r->height);
+		if (written < 0 || (size_t)written >= str_size - offset) {
+			break;
+		}
+		offset += written;
+
+		if (i < region->data->numRects - 1) {
+			written = snprintf(str + offset, str_size - offset, ",\n");
+		} else {
+			written = snprintf(str + offset, str_size - offset, "\n");
+		}
+		if (written < 0 || (size_t)written >= str_size - offset) {
+			break;
+		}
+		offset += written;
+	}
+
+	snprintf(str + offset, str_size - offset, "}");
+
+	return str;
+}
+
+bool wlf_region_from_str(const char *str, struct wlf_region *out_region) {
+	if (str == NULL || out_region == NULL) {
+		return false;
+	}
+
+	wlf_region_init(out_region);
+
+	const char *p = str;
+
+	while (*p && (*p == ' ' || *p == '\t' || *p == '\n' || *p == '{')) {
+		p++;
+	}
+
+	while (*p) {
+		while (*p && *p != '[') {
+			p++;
+		}
+
+		if (!*p) {
+			break;
+		}
+
+		p++;
+
+		double x, y, w, h;
+		int matched = sscanf(p, "%lf,%lf,%lf,%lf", &x, &y, &w, &h);
+		if (matched != 4) {
+			wlf_region_fini(out_region);
+			return false;
+		}
+
+		struct wlf_frect rect = {
+			.x = x,
+			.y = y,
+			.width = w,
+			.height = h,
+		};
+		if (!wlf_region_add_rect(out_region, &rect)) {
+			wlf_region_fini(out_region);
+			return false;
+		}
+
+		while (*p && *p != ']') {
+			p++;
+		}
+
+		if (*p) {
+			p++;
+		}
+
+		while (*p && (*p == ',' || *p == ' ' || *p == '\t' || *p == '\n')) {
+			p++;
+		}
+
+		if (*p == '}') {
+			break;
+		}
+	}
+
+	return true;
+}
+
+struct wlf_frect wlf_region_bounding_rect(const struct wlf_region *region) {
+	if (region == NULL || region->data == NULL || region->data->numRects == 0) {
+		return (struct wlf_frect){
+			.x = 0,
+			.y = 0,
+			.width = 0,
+			.height = 0,
+		};
+	}
+
+	return region->extents;
+}
+
+bool wlf_region_is_nil(const struct wlf_region *region) {
+	return region->data == NULL || region->data->numRects == 0;
+}
+
+bool wlf_region_add_rect(struct wlf_region *region, const struct wlf_frect *rect) {
+	if (!region->data) {
+		return false;
+	}
+
+	if (region->data->numRects >= region->data->size) {
+		long new_size = region->data->size * 2;
+		struct wlf_frect *new_rects = realloc(region->data->rects, new_size * sizeof(struct wlf_frect));
+		if (!new_rects) {
+			wlf_log(WLF_ERROR, "Failed to reallocate memory for wlf_region_data");
+			return false;
+		}
+		region->data->rects = new_rects;
+		region->data->size = new_size;
+	}
+
+	region->data->rects[region->data->numRects++] = *rect;
+
+	if (region->data->numRects == 1) {
+		region->extents = *rect;
+	} else {
+		region->extents = rect_union(&region->extents, rect);
+	}
+
+	return true;
+}
+
+bool wlf_region_contains_point(const struct wlf_region *region, double x, double y) {
+	if (region->data == NULL) {
+		return false;
+	}
+
+	for (long i = 0; i < region->data->numRects; ++i) {
+		const struct wlf_frect *r = &region->data->rects[i];
+		if (x >= r->x && x < r->x + r->width &&
+				y >= r->y && y < r->y + r->height) {
+			return true;
+		}
+	}
+
+	return false;
+}
+
+void wlf_region_intersects_rect(const struct wlf_region *region, const struct wlf_frect *rect,
+		struct wlf_region *result) {
+	wlf_region_fini(result);
+	wlf_region_init(result);
+
+	if (region == NULL || rect == NULL) {
+		return;
+	}
+
+	struct wlf_region rect_region;
+	wlf_region_init(&rect_region);
+	wlf_region_add_rect(&rect_region, rect);
+
+	wlf_region_intersect(region, &rect_region, result);
+}
+
+void wlf_region_union(struct wlf_region *dst, const struct wlf_region *src) {
+	if (src->data == NULL) {
+		return;
+	}
+
+	for (long i = 0; i < src->data->numRects; ++i) {
+		wlf_region_add_rect(dst, &src->data->rects[i]);
+	}
+}
+
+void wlf_region_intersect(const struct wlf_region *dst, const struct wlf_region *src, struct wlf_region *result) {
+	wlf_region_fini(result);
+	wlf_region_init(result);
+
+	if (dst->data == NULL || src->data == NULL) {
+		return;
+	}
+
+	struct wlf_frect *results_rect = malloc(sizeof(struct wlf_frect) * dst->data->numRects * src->data->numRects);
+	if (!results_rect) {
+		wlf_log(WLF_ERROR, "Failed to allocate memory for intersection results_rect");
+		return;
+	}
+
+	long count = 0;
+
+	for (long i = 0; i < dst->data->numRects; ++i) {
+		for (long j = 0; j < src->data->numRects; ++j) {
+			const struct wlf_frect *a = &dst->data->rects[i];
+			const struct wlf_frect *b = &src->data->rects[j];
+
+			double x1 = (a->x > b->x) ? a->x : b->x;
+			double y1 = (a->y > b->y) ? a->y : b->y;
+			double x2_a = a->x + a->width;
+			double x2_b = b->x + b->width;
+			double x2 = (x2_a < x2_b) ? x2_a : x2_b;
+			double y2_a = a->y + a->height;
+			double y2_b = b->y + b->height;
+			double y2 = (y2_a < y2_b) ? y2_a : y2_b;
+
+			if (x1 < x2 && y1 < y2) {
+				results_rect[count++] = (struct wlf_frect){
+					.x = x1,
+					.y = y1,
+					.width = x2 - x1,
+					.height = y2 - y1
+				};
+			}
+		}
+	}
+
+	for (long i = 0; i < count; ++i) {
+		wlf_region_add_rect(result, &results_rect[i]);
+	}
+
+	free(results_rect);
+}

--- a/math/wlf_size.c
+++ b/math/wlf_size.c
@@ -1,0 +1,117 @@
+#include "wlf/math/wlf_size.h"
+#include "wlf/utils/wlf_log.h"
+
+#include <stdlib.h>
+#include <stdio.h>
+#include <math.h>
+#include <assert.h>
+#include <string.h>
+
+#define WLF_SIZE_STRLEN 32
+
+char* wlf_size_to_str(const struct wlf_size *size) {
+	if (size == NULL) {
+		return strdup("(NULL)");
+	}
+
+	char *buffer = malloc(WLF_SIZE_STRLEN);
+	if (buffer == NULL) {
+		wlf_log(WLF_ERROR, "Memory allocation failed for wlf_size_to_str");
+		return NULL;
+	}
+
+	snprintf(buffer, WLF_SIZE_STRLEN, "(%d, %d)", size->width, size->height);
+
+	return buffer;
+}
+
+bool wlf_size_equal(const struct wlf_size *a, const struct wlf_size *b) {
+	return (a->width == b->width) && (a->height == b->height);
+}
+
+bool wlf_size_is_empty(const struct wlf_size *size) {
+	return (size->width == 0) || (size->height == 0);
+}
+
+struct wlf_size wlf_size_add(const struct wlf_size *a, const struct wlf_size *b) {
+	return (struct wlf_size){.width = a->width + b->width, .height = a->height + b->height};
+}
+
+struct wlf_size wlf_size_subtract(const struct wlf_size *a, const struct wlf_size *b) {
+	return (struct wlf_size){.width = a->width - b->width, .height = a->height - b->height};
+}
+
+struct wlf_size wlf_size_multiply(const struct wlf_size *size, double scalar) {
+	return (struct wlf_size){.width = (int)round(size->width * scalar), .height = (int)round(size->height * scalar)};
+}
+
+struct wlf_size wlf_size_divide(const struct wlf_size *size, double scalar) {
+	assert(scalar != 0.0);
+	return (struct wlf_size){.width = (int)round(size->width / scalar), .height = (int)round(size->height / scalar)};
+}
+
+int wlf_size_area(const struct wlf_size *size) {
+	return size->width * size->height;
+}
+
+bool wlf_size_from_str(const char *str, struct wlf_size *size) {
+	if (str == NULL || size == NULL) {
+		return false;
+	}
+
+	while (*str == ' ' || *str == '\t') {
+		str++;
+	}
+
+	if (*str != '(') {
+		return false;
+	}
+	str++;
+
+	char *endptr;
+	long width = strtol(str, &endptr, 10);
+	if (endptr == str) {
+		return false;
+	}
+	str = endptr;
+
+	while (*str == ' ' || *str == '\t') {
+		str++;
+	}
+
+	if (*str != ',') {
+		return false;
+	}
+	str++;
+
+	while (*str == ' ' || *str == '\t') {
+		str++;
+	}
+
+	long height = strtol(str, &endptr, 10);
+	if (endptr == str) {
+		return false;
+	}
+	str = endptr;
+
+	while (*str == ' ' || *str == '\t') {
+		str++;
+	}
+
+	if (*str != ')') {
+		return false;
+	}
+
+	size->width = (int)width;
+	size->height = (int)height;
+
+	return true;
+}
+
+bool wlf_size_is_valid(const struct wlf_size *size) {
+	if (size == NULL) {
+		return false;
+	}
+
+	return (size->width > 0) && (size->height > 0);
+}

--- a/math/wlf_vector2.c
+++ b/math/wlf_vector2.c
@@ -1,0 +1,79 @@
+#include "wlf/math/wlf_vector2.h"
+#include "wlf/utils/wlf_log.h"
+
+#include <stdlib.h>
+#include <stdio.h>
+#include <math.h>
+#include <assert.h>
+#include <string.h>
+
+#define WLF_VECTOR2_STRLEN 128
+
+char* wlf_vector2_to_str(const struct wlf_vector2 *vector) {
+	return wlf_vector2_to_str_prec(vector, 3);
+}
+
+char *wlf_vector2_to_str_prec(const struct wlf_vector2 *vector, uint8_t precision) {
+	if (vector == NULL) {
+		return strdup("(NULL)");
+	}
+
+	if (precision > 15) {
+		precision = 15;
+	}
+
+	char fmt[32];
+	snprintf(fmt, sizeof(fmt), "(%%.%df, %%.%df)", precision, precision);
+
+	char *buffer = malloc(WLF_VECTOR2_STRLEN);
+	if (buffer == NULL) {
+		wlf_log(WLF_ERROR, "Memory allocation failed for wlf_vector2_to_str_prec");
+		return NULL;
+	}
+
+	snprintf(buffer, WLF_VECTOR2_STRLEN, fmt, vector->u, vector->v);
+
+	return buffer;
+}
+
+struct wlf_vector2 wlf_vector2_add(const struct wlf_vector2 *a, const struct wlf_vector2 *b) {
+	return (struct wlf_vector2) {.u = a->u + b->u, .v = a->v + b->v};
+}
+
+struct wlf_vector2 wlf_vector2_subtract(const struct wlf_vector2 *a, const struct wlf_vector2 *b) {
+	return (struct wlf_vector2) {.u = a->u - b->u, .v = a->v - b->v};
+}
+
+struct wlf_vector2 wlf_vector2_multiply(const struct wlf_vector2 *vec, double scalar) {
+	return (struct wlf_vector2) {.u = vec->u * scalar, .v = vec->v * scalar};
+}
+
+struct wlf_vector2 wlf_vector2_divide(const struct wlf_vector2 *vec, double scalar) {
+	assert(scalar != 0.0);
+	return (struct wlf_vector2) {.u = vec->u / scalar, .v = vec->v / scalar};
+}
+
+double wlf_vector2_dot(const struct wlf_vector2 *a, const struct wlf_vector2 *b) {
+	return (a->u * b->u) + (a->v * b->v);
+}
+
+double wlf_vector2_magnitude(const struct wlf_vector2 *vec) {
+	return sqrt(vec->u * vec->u + vec->v * vec->v);
+}
+
+struct wlf_vector2 wlf_vector2_normalize(const struct wlf_vector2 *vec) {
+	double mag = wlf_vector2_magnitude(vec);
+	if (mag == 0) {
+		return WLF_VECTOR2_ZERO;
+	}
+
+	return (struct wlf_vector2) {.u = vec->u / mag, .v = vec->v / mag};
+}
+
+bool wlf_vector2_equal(const struct wlf_vector2 *a, const struct wlf_vector2 *b) {
+	return (a->u == b->u) && (a->v == b->v);
+}
+
+bool wlf_vector2_nearly_equal(const struct wlf_vector2 *a, const struct wlf_vector2 *b, double epsilon) {
+	return (fabs(a->u - b->u) < epsilon) && (fabs(a->v - b->v) < epsilon);
+}

--- a/math/wlf_vector3.c
+++ b/math/wlf_vector3.c
@@ -1,0 +1,92 @@
+#include "wlf/math/wlf_vector3.h"
+#include "wlf/utils/wlf_log.h"
+
+#include <stdlib.h>
+#include <stdio.h>
+#include <math.h>
+#include <assert.h>
+#include <string.h>
+
+#define WLF_VECTOR3_STRLEN 192
+
+struct wlf_vector3 wlf_vector3_make(double x, double y, double z) {
+	return (struct wlf_vector3) {.x = x, .y = y, .z = z};
+}
+
+char* wlf_vector3_to_str(const struct wlf_vector3 *vector) {
+	return wlf_vector3_to_str_prec(vector, 3);
+}
+
+char *wlf_vector3_to_str_prec(const struct wlf_vector3 *vector, uint8_t precision) {
+	if (vector == NULL) {
+		return strdup("(NULL)");
+	}
+
+	if (precision > 15) {
+		precision = 15;
+	}
+
+	char fmt[48];
+	snprintf(fmt, sizeof(fmt), "(%%.%df, %%.%df, %%.%df)", precision, precision, precision);
+
+	char *buffer = malloc(WLF_VECTOR3_STRLEN);
+	if (buffer == NULL) {
+		wlf_log(WLF_ERROR, "Memory allocation failed for wlf_vector3_to_str_prec");
+		return NULL;
+	}
+
+	snprintf(buffer, WLF_VECTOR3_STRLEN, fmt, vector->x, vector->y, vector->z);
+
+	return buffer;
+}
+
+struct wlf_vector3 wlf_vector3_add(const struct wlf_vector3 *a, const struct wlf_vector3 *b) {
+	return wlf_vector3_make(a->x + b->x, a->y + b->y, a->z + b->z);
+}
+
+struct wlf_vector3 wlf_vector3_subtract(const struct wlf_vector3 *a, const struct wlf_vector3 *b) {
+	return wlf_vector3_make(a->x - b->x, a->y - b->y, a->z - b->z);
+}
+
+struct wlf_vector3 wlf_vector3_multiply(const struct wlf_vector3 *vec, double scalar) {
+	return wlf_vector3_make(vec->x * scalar, vec->y * scalar, vec->z * scalar);
+}
+
+struct wlf_vector3 wlf_vector3_divide(const struct wlf_vector3 *vec, double scalar) {
+	assert(scalar != 0.0);
+	return wlf_vector3_make(vec->x / scalar, vec->y / scalar, vec->z / scalar);
+}
+
+double wlf_vector3_dot(const struct wlf_vector3 *a, const struct wlf_vector3 *b) {
+	return (a->x * b->x) + (a->y * b->y) + (a->z * b->z);
+}
+
+struct wlf_vector3 wlf_vector3_cross(const struct wlf_vector3 *a, const struct wlf_vector3 *b) {
+	return wlf_vector3_make(
+			a->y * b->z - a->z * b->y,
+			a->z * b->x - a->x * b->z,
+			a->x * b->y - a->y * b->x
+	);
+}
+
+double wlf_vector3_magnitude(const struct wlf_vector3 *vec) {
+	return sqrt(vec->x * vec->x + vec->y * vec->y + vec->z * vec->z);
+}
+
+struct wlf_vector3 wlf_vector3_normalize(const struct wlf_vector3 *vec) {
+	double mag = wlf_vector3_magnitude(vec);
+	if (mag == 0) {
+		// Return zero vector if magnitude is zero
+		return WLF_VECTOR3_ZERO;
+    }
+
+	return wlf_vector3_make(vec->x / mag, vec->y / mag, vec->z / mag);
+}
+
+bool wlf_vector3_equal(const struct wlf_vector3 *a, const struct wlf_vector3 *b) {
+	return (a->x == b->x) && (a->y == b->y) && (a->z == b->z);
+}
+
+bool wlf_vector3_nearly_equal(const struct wlf_vector3 *a, const struct wlf_vector3 *b, double epsilon) {
+	return (fabs(a->x - b->x) < epsilon) && (fabs(a->y - b->y) < epsilon) && (fabs(a->z - b->z) < epsilon);
+}

--- a/math/wlf_vector4.c
+++ b/math/wlf_vector4.c
@@ -1,0 +1,87 @@
+#include "wlf/math/wlf_vector4.h"
+#include "wlf/utils/wlf_log.h"
+
+#include <stdlib.h>
+#include <stdio.h>
+#include <math.h>
+#include <string.h>
+#include <assert.h>
+
+#define WLF_VECTOR4_STRLEN 256
+
+struct wlf_vector4 wlf_vector4_make(double x, double y, double z, double w) {
+	struct wlf_vector4 vec = {x, y, z, w};
+
+	return vec;
+}
+
+char* wlf_vector4_to_str(const struct wlf_vector4 *vector) {
+	return wlf_vector4_to_str_prec(vector, 3);
+}
+
+char *wlf_vector4_to_str_prec(const struct wlf_vector4 *vector, uint8_t precision) {
+	if (vector == NULL) {
+		return strdup("(NULL)");
+	}
+
+	if (precision > 15) {
+		precision = 15;
+	}
+
+	char fmt[64];
+	snprintf(fmt, sizeof(fmt), "(%%.%df, %%.%df, %%.%df, %%.%df)", precision, precision, precision, precision);
+
+	char *buffer = malloc(WLF_VECTOR4_STRLEN);
+	if (buffer == NULL) {
+		wlf_log(WLF_ERROR, "Memory allocation failed for wlf_vector4_to_str_prec");
+		return NULL;
+	}
+
+	snprintf(buffer, WLF_VECTOR4_STRLEN, fmt, vector->x, vector->y, vector->z, vector->w);
+
+	return buffer;
+}
+
+struct wlf_vector4 wlf_vector4_add(const struct wlf_vector4 *a, const struct wlf_vector4 *b) {
+	return wlf_vector4_make(a->x + b->x, a->y + b->y, a->z + b->z, a->w + b->w);
+}
+
+struct wlf_vector4 wlf_vector4_subtract(const struct wlf_vector4 *a, const struct wlf_vector4 *b) {
+	return wlf_vector4_make(a->x - b->x, a->y - b->y, a->z - b->z, a->w - b->w);
+}
+
+struct wlf_vector4 wlf_vector4_multiply(const struct wlf_vector4 *vec, double scalar) {
+	return wlf_vector4_make(vec->x * scalar, vec->y * scalar, vec->z * scalar, vec->w * scalar);
+}
+
+struct wlf_vector4 wlf_vector4_divide(const struct wlf_vector4 *vec, double scalar) {
+	assert(scalar != 0.0);
+	return wlf_vector4_make(vec->x / scalar, vec->y / scalar, vec->z / scalar, vec->w / scalar);
+}
+
+double wlf_vector4_dot(const struct wlf_vector4 *a, const struct wlf_vector4 *b) {
+	return (a->x * b->x) + (a->y * b->y) + (a->z * b->z) + (a->w * b->w);
+}
+
+double wlf_vector4_magnitude(const struct wlf_vector4 *vec) {
+	return sqrt(vec->x * vec->x + vec->y * vec->y + vec->z * vec->z + vec->w * vec->w);
+}
+
+struct wlf_vector4 wlf_vector4_normalize(const struct wlf_vector4 *vec) {
+	double mag = wlf_vector4_magnitude(vec);
+	if (mag == 0) {
+		// Return zero vector if magnitude is zero
+		return WLF_VECTOR4_ZERO;
+	}
+
+	return wlf_vector4_make(vec->x / mag, vec->y / mag, vec->z / mag, vec->w / mag);
+}
+
+bool wlf_vector4_equal(const struct wlf_vector4 *a, const struct wlf_vector4 *b) {
+	return (a->x == b->x) && (a->y == b->y) && (a->z == b->z) && (a->w == b->w);
+}
+
+bool wlf_vector4_nearly_equal(const struct wlf_vector4 *a, const struct wlf_vector4 *b, double epsilon) {
+	return (fabs(a->x - b->x) < epsilon) && (fabs(a->y - b->y) < epsilon) &&
+			(fabs(a->z - b->z) < epsilon) && (fabs(a->w - b->w) < epsilon);
+}

--- a/meson.build
+++ b/meson.build
@@ -133,6 +133,7 @@ if is_linux
 	subdir('wayland')
 endif
 subdir('image')
+subdir('math')
 
 wlf_inc = include_directories('include')
 


### PR DESCRIPTION
- Include the `math` subdirectory in the top-level and examples Meson builds  
- Implement core math types (`vector2/3/4`, `point`, `size`, `rect`, `f*` variants, `region`, `ray2/3`, `quaternion`, `matrix3x3/4x4`) and their headers  