### PR TITLE
backend: add fd event sources and event loop interface

### DIFF
--- a/include/wlf/platform/wlf_backend.h
+++ b/include/wlf/platform/wlf_backend.h
@@ -23,24 +23,32 @@
 
 #include "wlf/utils/wlf_signal.h"
 #include "wlf/utils/wlf_linked_list.h"
-#include "wlf/types/wlf_output.h"
 
 #include <stdbool.h>
 #include <stdint.h>
+#include <stddef.h>
 
 struct wlf_backend;
+
+typedef void (*wlf_backend_event_source_dispatch_t)(
+	struct wlf_backend *backend, int fd, uint32_t revents, void *data);
 
 /**
  * @brief Backend implementation interface
  * This structure defines the function pointers that each backend must implement
  */
 struct wlf_backend_impl {
-	const char *name;
+	const char *name;  /**< Backend implementation name */
 	/**
 	 * @brief Destroy the backend and free resources
 	 * @param backend Pointer to the backend
 	 */
 	void (*destroy)(struct wlf_backend *backend);
+	/**
+	 * @brief Run the backend main event loop
+	 * @param backend Pointer to the backend
+	 */
+	void (*exe)(struct wlf_backend *backend);
 };
 
 /**
@@ -48,6 +56,16 @@ struct wlf_backend_impl {
  */
 struct wlf_backend {
 	const struct wlf_backend_impl *impl;  /**< Backend implementation */
+	bool running;  /**< True while backend event loop is running */
+
+	struct {
+		int fd;  /**< File descriptor to monitor */
+		short events;  /**< poll(2) event mask */
+		wlf_backend_event_source_dispatch_t dispatch;  /**< Event callback */
+		void *data;  /**< User data passed to callback */
+	} *event_sources;  /**< Dynamic event source array */
+	size_t event_source_count;  /**< Number of active event sources */
+	size_t event_source_capacity;  /**< Allocated event source capacity */
 
 	struct {
 		struct wlf_signal destroy;        /**< Emitted when backend is destroyed */
@@ -61,9 +79,14 @@ struct wlf_backend {
 	 */
 	void *data;
 
-	struct wlf_linked_list outputs;
+	struct wlf_linked_list outputs;  /**< Managed output list */
 };
 
+/**
+ * @brief Initialize a backend object
+ * @param backend Pointer to backend object to initialize
+ * @param impl Backend implementation vtable
+ */
 void wlf_backend_init(struct wlf_backend *backend,
 	const struct wlf_backend_impl *impl);
 
@@ -78,5 +101,41 @@ struct wlf_backend *wlf_backend_autocreate(void);
  * @param backend Pointer to the backend
  */
 void wlf_backend_destroy(struct wlf_backend *backend);
+
+/**
+ * @brief Execute backend event loop
+ * @param backend Pointer to backend
+ */
+void wlf_backend_exe(struct wlf_backend *backend);
+
+/**
+ * @brief Register an external file descriptor event source
+ * @param backend Pointer to backend
+ * @param fd File descriptor to poll
+ * @param events poll(2) event mask
+ * @param dispatch Callback invoked when events occur
+ * @param data User data passed to dispatch callback
+ * @return true on success, false on failure
+ */
+bool wlf_backend_add_event_source(struct wlf_backend *backend,
+	int fd, short events,
+	wlf_backend_event_source_dispatch_t dispatch,
+	void *data);
+
+/**
+ * @brief Unregister a previously added event source
+ * @param backend Pointer to backend
+ * @param fd File descriptor used during registration
+ * @param data User data used during registration
+ * @return true if removed, false if not found
+ */
+bool wlf_backend_remove_event_source(struct wlf_backend *backend,
+	int fd, void *data);
+
+/**
+ * @brief Request backend event loop termination
+ * @param backend Pointer to backend
+ */
+void wlf_backend_quit(struct wlf_backend *backend);
 
 #endif // PLATFORM_WLF_BACKEND_H

--- a/platform/wlf_backend.c
+++ b/platform/wlf_backend.c
@@ -3,7 +3,6 @@
 #include "wlf/utils/wlf_linked_list.h"
 #include "wlf/utils/wlf_log.h"
 #include "wlf/utils/wlf_env.h"
-#include "wlf/utils/wlf_utils.h"
 #include "wlf/utils/wlf_signal.h"
 #if WLF_HAS_LINUX_PLATFORM
 #include "wlf/platform/wayland/backend.h"
@@ -19,6 +18,8 @@
 void wlf_backend_init(struct wlf_backend *backend,
 		const struct wlf_backend_impl *impl) {
 	assert(impl->destroy);
+	assert(impl->name);
+	assert(impl->exe);
 
 	*backend = (struct wlf_backend){
 		.impl = impl,
@@ -54,10 +55,76 @@ void wlf_backend_destroy(struct wlf_backend *backend) {
 	wlf_log(WLF_DEBUG, "Destroying backend %s", backend->impl->name);
 
 	wlf_signal_emit_mutable(&backend->events.destroy, backend);
+	free(backend->event_sources);
+	backend->event_sources = NULL;
+	backend->event_source_count = 0;
+	backend->event_source_capacity = 0;
 
 	if (backend->impl && backend->impl->destroy) {
 		backend->impl->destroy(backend);
 	} else {
 		free(backend);
 	}
+}
+
+void wlf_backend_exe(struct wlf_backend *backend) {
+	backend->impl->exe(backend);
+}
+
+bool wlf_backend_add_event_source(struct wlf_backend *backend,
+		int fd, short events,
+		wlf_backend_event_source_dispatch_t dispatch,
+		void *data) {
+	assert(backend != NULL);
+	assert(dispatch != NULL);
+
+	if (fd < 0) {
+		wlf_log(WLF_ERROR, "Invalid fd for backend event source");
+		return false;
+	}
+
+	if (backend->event_source_count == backend->event_source_capacity) {
+		size_t new_capacity = backend->event_source_capacity == 0 ? 4 : backend->event_source_capacity * 2;
+		void *new_sources = realloc(backend->event_sources,
+			new_capacity * sizeof(*backend->event_sources));
+		if (new_sources == NULL) {
+			wlf_log_errno(WLF_ERROR, "Failed to grow backend event source array");
+			return false;
+		}
+
+		backend->event_sources = new_sources;
+		backend->event_source_capacity = new_capacity;
+	}
+
+	backend->event_sources[backend->event_source_count].fd = fd;
+	backend->event_sources[backend->event_source_count].events = events;
+	backend->event_sources[backend->event_source_count].dispatch = dispatch;
+	backend->event_sources[backend->event_source_count].data = data;
+	backend->event_source_count++;
+
+	return true;
+}
+
+bool wlf_backend_remove_event_source(struct wlf_backend *backend,
+		int fd, void *data) {
+	assert(backend != NULL);
+
+	for (size_t i = 0; i < backend->event_source_count; ++i) {
+		if (backend->event_sources[i].fd == fd && backend->event_sources[i].data == data) {
+			if (i + 1 < backend->event_source_count) {
+				memmove(&backend->event_sources[i],
+					&backend->event_sources[i + 1],
+					(backend->event_source_count - i - 1) * sizeof(*backend->event_sources));
+			}
+
+			backend->event_source_count--;
+			return true;
+		}
+	}
+
+	return false;
+}
+
+void wlf_backend_quit(struct wlf_backend *backend) {
+	backend->running = false;
 }


### PR DESCRIPTION
Add support for registering pollable fd sources on the backend with per-source dispatch callbacks, along with an impl->exe hook to drive the main loop.