### PR TITLE
math/wlf_region: Enhance region API with rectangle support

### DIFF
--- a/include/wlf/math/wlf_region.h
+++ b/include/wlf/math/wlf_region.h
@@ -47,6 +47,13 @@ struct wlf_region {
 void wlf_region_init(struct wlf_region *region);
 
 /**
+ * @brief Initialize a region object with a rectangle.
+ * @param region Pointer to the region object.
+ * @param rect Pointer to the initial rectangle.
+ */
+void wlf_region_init_rect(struct wlf_region *region, const struct wlf_frect *rect);
+
+/**
  * @brief Finalize a region object and release its resources.
  * @param region Pointer to the region object.
  */
@@ -114,6 +121,15 @@ void wlf_region_intersects_rect(const struct wlf_region *region, const struct wl
  * @param src Source region object pointer.
  */
 void wlf_region_union(struct wlf_region *dst, const struct wlf_region *src);
+
+/**
+ * @brief Compute the union of a region and a rectangle.
+ * @param dst Destination region object pointer, result will be written here.
+ * @param src Source region object pointer.
+ * @param rect Pointer to the rectangle to union.
+ * @note The result is: dst = src ∪ rect
+ */
+void wlf_region_union_rect(struct wlf_region *dst, struct wlf_region *src, const struct wlf_frect *rect);
 
 /**
  * @brief Compute the intersection of two regions.

--- a/math/wlf_region.c
+++ b/math/wlf_region.c
@@ -306,3 +306,19 @@ void wlf_region_intersect(const struct wlf_region *dst, const struct wlf_region 
 
 	free(results_rect);
 }
+
+void wlf_region_init_rect(struct wlf_region *region, const struct wlf_frect *rect) {
+	wlf_region_init(region);
+	wlf_region_add_rect(region, rect);
+}
+
+void wlf_region_union_rect(struct wlf_region *dst, struct wlf_region *src, const struct wlf_frect *rect) {
+	wlf_region_fini(dst);
+	wlf_region_init(dst);
+
+	for (long i = 0; i < src->data->numRects; ++i) {
+		wlf_region_add_rect(dst, &src->data->rects[i]);
+	}
+
+	wlf_region_add_rect(dst, rect);
+}


### PR DESCRIPTION
Adds two new functions to streamline region handling:
1. wlf_region_init_rect: For quick initialization of a region from a single rectangle.
2. wlf_region_union_rect: To perform the union operation between a region and a rectangle.