### PR TITLE
platform/wlf_backend: add native_display backend interface

### DIFF
--- a/include/wlf/platform/wlf_backend.h
+++ b/include/wlf/platform/wlf_backend.h
@@ -49,6 +49,24 @@ struct wlf_backend_impl {
 	 * @param backend Pointer to the backend
 	 */
 	void (*exe)(struct wlf_backend *backend);
+
+	/**
+	 * @brief Get the native display handle used by the backend
+	 *
+	 * Returns the underlying platform-specific display object associated
+	 * with this backend. The returned pointer type depends on the backend
+	 * implementation.
+	 *
+	 * Examples:
+	 * - Wayland backend: struct wl_display *
+	 *
+	 * The returned pointer is owned by the backend and must not be freed
+	 * or modified by the caller.
+	 *
+	 * @param backend Pointer to the backend
+	 * @return Native display handle, or NULL if unsupported
+	 */
+	void *(*native_display)(struct wlf_backend *backend);
 };
 
 /**

--- a/platform/wayland/backend.c
+++ b/platform/wayland/backend.c
@@ -991,10 +991,18 @@ out:
 	backend->running = false;
 }
 
+static void *backend_native_display(struct wlf_backend *backend) {
+	struct wlf_wl_backend *wayland_backend =
+		wlf_wl_backend_from_backend(backend);
+
+	return wayland_backend->display;
+}
+
 static const struct wlf_backend_impl wayland_backend_impl = {
 	.name = "Wayland",
 	.destroy = backend_destroy,
 	.exe = backend_exe,
+	.native_display = backend_native_display,
 };
 
 struct wlf_backend *wayland_backend_create(void) {

--- a/platform/wlf_backend.c
+++ b/platform/wlf_backend.c
@@ -17,9 +17,10 @@
 
 void wlf_backend_init(struct wlf_backend *backend,
 		const struct wlf_backend_impl *impl) {
-	assert(impl->destroy);
-	assert(impl->name);
-	assert(impl->exe);
+	assert(impl->destroy != NULL &&
+		impl->name != NULL &&
+		impl->exe != NULL &&
+		impl->native_display != NULL);
 
 	*backend = (struct wlf_backend){
 		.impl = impl,


### PR DESCRIPTION
Implement this callback for the Wayland backend and return the associated wl_display object.