### PR TITLE
renderer: add damage tracking capability flag

### DIFF
--- a/include/wlf/renderer/vulkan/device.h
+++ b/include/wlf/renderer/vulkan/device.h
@@ -45,6 +45,7 @@ struct wlf_vk_device {
 	bool sync_file_import_export;     /**< Whether the device supports sync file import/export (VK_EXT_external_fd). */
 	bool implicit_sync_interop;       /**< Whether implicit synchronization interop is supported. */
 	bool sampler_ycbcr_conversion;    /**< Whether the device supports YCbCr sampler conversion. */
+	bool incremental_present;         /**< Whether the device supports VK_KHR_incremental_present for damage tracking. */
 
 	uint32_t queue_family;            /**< Index of the primary queue family used for rendering and transfer. */
 	VkQueue queue;                    /**< Primary Vulkan queue used for command submission. */

--- a/include/wlf/renderer/wlf_renderer.h
+++ b/include/wlf/renderer/wlf_renderer.h
@@ -65,6 +65,10 @@ struct wlf_renderer {
 
 	void *data;                    /**< Backend-specific user data (opaque pointer). */
 
+	struct {
+		bool damage;               /**< Whether the renderer supports damage-based partial updates. */
+	} features;                    /**< Optional renderer feature capabilities. */
+
 	enum wlf_renderer_type type;   /**< Type of renderer backend. */
 };
 

--- a/renderer/pixman/renderer.c
+++ b/renderer/pixman/renderer.c
@@ -95,6 +95,7 @@ struct wlf_renderer *wlf_pixman_renderer_create_from_backend(
 	wlf_linked_list_init(&renderer->textures);
 	renderer->base.type = CPU;
 	renderer->backend = backend;
+	renderer->base.features.damage = true;
 
 	return &renderer->base;
 }

--- a/renderer/vulkan/device.c
+++ b/renderer/vulkan/device.c
@@ -167,6 +167,15 @@ struct wlf_vk_device *wlf_vk_device_create(struct wlf_vk_instance *instance,
 	wlf_log(WLF_DEBUG, "Sampler YCbCr conversion %s",
 		dev->sampler_ycbcr_conversion ? "supported" : "not supported");
 
+	dev->incremental_present = check_extension(avail_ext_props, avail_extc,
+		VK_KHR_INCREMENTAL_PRESENT_EXTENSION_NAME);
+	if (dev->incremental_present) {
+		extensions[extensions_len++] = VK_KHR_INCREMENTAL_PRESENT_EXTENSION_NAME;
+		wlf_log(WLF_DEBUG, "Vulkan incremental present (damage tracking) supported");
+	} else {
+		wlf_log(WLF_DEBUG, "Vulkan incremental present not supported, damage tracking disabled");
+	}
+
 	const float prio = 1.f;
 	VkDeviceQueueCreateInfo qinfo = {
 		.sType = VK_STRUCTURE_TYPE_DEVICE_QUEUE_CREATE_INFO,

--- a/renderer/vulkan/renderer.c
+++ b/renderer/vulkan/renderer.c
@@ -118,6 +118,8 @@ struct wlf_renderer *wlf_vk_render_create_for_device(struct wlf_vk_device *devic
 		render->base.type = GPU;
 	}
 
+	render->base.features.damage = device->incremental_present;
+
 	VkCommandPoolCreateInfo cpool_info = {
 		.sType = VK_STRUCTURE_TYPE_COMMAND_POOL_CREATE_INFO,
 		.flags = VK_COMMAND_POOL_CREATE_RESET_COMMAND_BUFFER_BIT,


### PR DESCRIPTION
Detect support for VK_KHR_incremental_present on Vulkan devices and expose renderer damage tracking capability through the generic renderer feature flags.

When supported, the Vulkan renderer enables damage-based presentation optimizations via incremental present regions.

The Pixman renderer always supports damage tracking.