### PR TITLE
macos/theme: split appearance and highlight change handling on macOS

### DIFF
--- a/examples/platform/theme_palette_test.c
+++ b/examples/platform/theme_palette_test.c
@@ -12,33 +12,17 @@ struct wlf_listener theme_destroy_listener;
 struct wlf_listener theme_changed_listener;
 struct wlf_listener highlight_changed_listener;
 
-static const char *appearance_name(enum wlf_theme_appearance appearance) {
-	switch (appearance) {
-	case WLF_THEME_APPEARANCE_DARK:
-		return "dark";
-	case WLF_THEME_APPEARANCE_LIGHT:
-	default:
-		return "light";
-	}
-}
-
 static const char *role_name(enum wlf_theme_color_role role);
 
 static void print_theme_summary(struct wlf_theme *theme) {
 	static const enum wlf_theme_color_role roles[] = {
-		WLF_THEME_COLOR_WINDOW,
-		WLF_THEME_COLOR_WINDOW_TEXT,
-		WLF_THEME_COLOR_BASE,
-		WLF_THEME_COLOR_TEXT,
-		WLF_THEME_COLOR_BUTTON,
-		WLF_THEME_COLOR_ACCENT,
 		WLF_THEME_COLOR_HIGHLIGHT,
-		WLF_THEME_COLOR_ERROR,
 	};
 	size_t i;
 
 	wlf_log(WLF_INFO, "theme implementation: %s", theme->impl->name);
-	wlf_log(WLF_INFO, "appearance: %s", appearance_name(theme->appearance));
+	wlf_log(WLF_INFO, "appearance: %s",
+		wlf_theme_appearance_name(theme->appearance));
 
 	for (i = 0; i < sizeof(roles) / sizeof(roles[0]); ++i) {
 		struct wlf_color color = wlf_theme_palette_color(theme, roles[i]);
@@ -57,13 +41,10 @@ static void theme_destroy_notify(struct wlf_listener *listener, void *data) {
 
 static void theme_changed_notify(struct wlf_listener *listener, void *data) {
 	struct wlf_theme *theme = data;
-	struct wlf_color highlight =
-		wlf_theme_palette_color(theme, WLF_THEME_COLOR_HIGHLIGHT);
 	(void)listener;
 
-	wlf_log(WLF_INFO, "theme_changed: appearance=%s highlight=#%06X",
-		appearance_name(theme->appearance),
-		wlf_color_to_hex_rgb(&highlight));
+	wlf_log(WLF_INFO, "theme_changed: appearance=%s",
+		wlf_theme_appearance_name(theme->appearance));
 }
 
 static void highlight_changed_notify(struct wlf_listener *listener, void *data) {
@@ -86,22 +67,8 @@ static void handle_sigint(int signo) {
 
 static const char *role_name(enum wlf_theme_color_role role) {
 	switch (role) {
-	case WLF_THEME_COLOR_WINDOW:
-		return "window";
-	case WLF_THEME_COLOR_WINDOW_TEXT:
-		return "window_text";
-	case WLF_THEME_COLOR_BASE:
-		return "base";
-	case WLF_THEME_COLOR_TEXT:
-		return "text";
-	case WLF_THEME_COLOR_BUTTON:
-		return "button";
-	case WLF_THEME_COLOR_ACCENT:
-		return "accent";
 	case WLF_THEME_COLOR_HIGHLIGHT:
 		return "highlight";
-	case WLF_THEME_COLOR_ERROR:
-		return "error";
 	default:
 		return "other";
 	}

--- a/include/wlf/platform/macos/theme.h
+++ b/include/wlf/platform/macos/theme.h
@@ -21,9 +21,8 @@
  * @brief macOS theme specific data.
  *
  * Extends the generic theme object with the resolved semantic palette and
- * AppKit notification observer state. The palette maps wlframe accent to the
- * resolved theme accent color, while the highlight roles track the current
- * macOS selection colors independently from the light/dark theme palette.
+ * AppKit notification observer state. The palette tracks the current macOS
+ * selection highlight color independently from the light/dark appearance.
  */
 struct wlf_macos_theme {
 	struct wlf_theme base;  /**< Base theme structure. */
@@ -36,8 +35,9 @@ struct wlf_macos_theme {
  * @brief Creates a macOS-backed theme object.
  *
  * The returned theme uses AppKit to detect the current effective appearance,
- * resolves the current system accent and highlight colors, and listens for
- * appearance and system color changes so `theme_changed` can be emitted.
+ * resolves the current system highlight color, and listens for
+ * appearance and system color changes so `theme_changed` and
+ * `highlight_changed` can be emitted.
  *
  * @return A newly allocated macOS theme, or NULL on failure.
  */
@@ -47,8 +47,8 @@ struct wlf_macos_theme *wlf_macos_theme_create(void);
  * @brief Reloads the macOS theme from current system settings.
  *
  * Re-resolves appearance and system colors, then emits `theme_changed` when
- * any palette role changes and `highlight_changed` when the highlight roles
- * change.
+ * the resolved light/dark appearance changes and `highlight_changed` when the
+ * highlight color changes.
  *
  * @param theme macOS theme to refresh. NULL is allowed.
  */

--- a/include/wlf/platform/wlf_theme.h
+++ b/include/wlf/platform/wlf_theme.h
@@ -32,29 +32,11 @@ enum wlf_theme_appearance {
 /**
  * @brief Semantic color roles for wlframe themes.
  *
- * These roles provide semantic access to colors so rendering code can request
- * "window", "text", or "highlight" colors without depending on fixed values.
+ * These roles provide semantic access to colors exposed directly by the
+ * platform theme backend.
  */
 enum wlf_theme_color_role {
-	WLF_THEME_COLOR_WINDOW = 0,  /**< Main window background color. */
-	WLF_THEME_COLOR_WINDOW_TEXT,  /**< Primary text color shown on window backgrounds. */
-	WLF_THEME_COLOR_BASE,  /**< Default content or input background color. */
-	WLF_THEME_COLOR_ALTERNATE_BASE,  /**< Alternate content background for striped or secondary surfaces. */
-	WLF_THEME_COLOR_TEXT,  /**< Primary foreground text color for content areas. */
-	WLF_THEME_COLOR_BUTTON,  /**< Default button background color. */
-	WLF_THEME_COLOR_BUTTON_TEXT,  /**< Text color shown on button surfaces. */
-	WLF_THEME_COLOR_BORDER,  /**< Border or outline color for controls and surfaces. */
-	WLF_THEME_COLOR_SEPARATOR,  /**< Divider or separator line color. */
-	WLF_THEME_COLOR_PLACEHOLDER_TEXT,  /**< Placeholder or hint text color. */
-	WLF_THEME_COLOR_ACCENT,  /**< Primary system accent or tint color. */
-	WLF_THEME_COLOR_HIGHLIGHT,  /**< Active selection or highlight background color. */
-	WLF_THEME_COLOR_HIGHLIGHTED_TEXT,  /**< Foreground color shown on highlighted content. */
-	WLF_THEME_COLOR_LINK,  /**< Hyperlink color for unvisited links. */
-	WLF_THEME_COLOR_VISITED_LINK,  /**< Hyperlink color for visited links. */
-	WLF_THEME_COLOR_MARK,  /**< Marked or emphasized annotation background color. */
-	WLF_THEME_COLOR_SUCCESS,  /**< Positive status or success feedback color. */
-	WLF_THEME_COLOR_WARNING,  /**< Warning or caution feedback color. */
-	WLF_THEME_COLOR_ERROR,  /**< Error or destructive feedback color. */
+	WLF_THEME_COLOR_HIGHLIGHT = 0,  /**< Active selection or highlight color. */
 	WLF_THEME_COLOR_COUNT,  /**< Total number of semantic theme color roles. */
 };
 
@@ -77,13 +59,13 @@ struct wlf_theme_impl {
  * @brief Theme object with platform and appearance metadata.
  *
  * A theme exposes the current appearance state and emits lifecycle,
- * palette-change, and highlight-change notifications that renderers or
+ * appearance-change, and highlight-change notifications that renderers or
  * widgets can observe.
  *
  * @code
  * struct wlf_theme *theme = wlf_theme_autocreate();
- * struct wlf_color accent =
- * 	wlf_theme_palette_color(theme, WLF_THEME_COLOR_ACCENT);
+ * struct wlf_color highlight =
+ * 	wlf_theme_palette_color(theme, WLF_THEME_COLOR_HIGHLIGHT);
  * @endcode
  */
 struct wlf_theme {
@@ -93,8 +75,8 @@ struct wlf_theme {
 
 	struct {
 		struct wlf_signal destroy;        /**< Emitted before the theme is destroyed. */
-		struct wlf_signal theme_changed;  /**< Emitted when system appearance or palette changes. */
-		struct wlf_signal highlight_changed;  /**< Emitted when highlight background or foreground colors change. */
+		struct wlf_signal theme_changed;  /**< Emitted when the resolved appearance changes between light and dark. */
+		struct wlf_signal highlight_changed;  /**< Emitted when the highlight color changes. */
 	} events;
 };
 
@@ -129,6 +111,15 @@ struct wlf_theme *wlf_theme_autocreate(void);
  * @param theme Theme to destroy. NULL is allowed.
  */
 void wlf_theme_destroy(struct wlf_theme *theme);
+
+/**
+ * @brief Returns a stable string for a theme appearance value.
+ *
+ * @param appearance Appearance enum value to stringify.
+ * @return `"light"` or `"dark"`.
+ */
+const char *wlf_theme_appearance_name(
+	enum wlf_theme_appearance appearance);
 
 /**
  * @brief Resolves a color for a semantic theme role.

--- a/platform/macos/theme.m
+++ b/platform/macos/theme.m
@@ -17,8 +17,7 @@
 @end
 
 static void macos_theme_fill_palette(
-	struct wlf_color palette[WLF_THEME_COLOR_COUNT],
-	enum wlf_theme_appearance appearance);
+	struct wlf_color palette[WLF_THEME_COLOR_COUNT]);
 
 static bool macos_theme_parse_appearance(const char *value,
 		enum wlf_theme_appearance *appearance) {
@@ -70,51 +69,6 @@ static enum wlf_theme_appearance macos_theme_detect_appearance(void) {
 	return WLF_THEME_APPEARANCE_LIGHT;
 }
 
-static NSAppearance *macos_theme_nsappearance(
-		enum wlf_theme_appearance appearance) {
-	return appearance == WLF_THEME_APPEARANCE_DARK ?
-		[NSAppearance appearanceNamed:NSAppearanceNameDarkAqua] :
-		[NSAppearance appearanceNamed:NSAppearanceNameAqua];
-}
-
-static struct wlf_color macos_theme_color_from_nscolor(NSColor *color,
-		enum wlf_theme_appearance appearance,
-		struct wlf_color fallback) {
-	if (color == nil) {
-		return fallback;
-	}
-
-	@autoreleasepool {
-		__block NSColor *resolved = nil;
-		NSAppearance *nsappearance = macos_theme_nsappearance(appearance);
-
-		if (@available(macOS 11.0, *)) {
-			[nsappearance performAsCurrentDrawingAppearance:^{
-				resolved = [color colorUsingColorSpace:NSColorSpace.sRGBColorSpace];
-			}];
-		} else {
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
-			NSAppearance *previous_appearance = NSAppearance.currentAppearance;
-			NSAppearance.currentAppearance = nsappearance;
-			resolved = [color colorUsingColorSpace:NSColorSpace.sRGBColorSpace];
-			NSAppearance.currentAppearance = previous_appearance;
-#pragma clang diagnostic pop
-		}
-
-		if (resolved == nil) {
-			return fallback;
-		}
-
-		return (struct wlf_color){
-			.r = resolved.redComponent,
-			.g = resolved.greenComponent,
-			.b = resolved.blueComponent,
-			.a = resolved.alphaComponent,
-		};
-	}
-}
-
 static struct wlf_color macos_theme_color_from_nscolor_current(NSColor *color,
 		struct wlf_color fallback) {
 	if (color == nil) {
@@ -138,23 +92,14 @@ static struct wlf_color macos_theme_color_from_nscolor_current(NSColor *color,
 }
 
 static void macos_theme_apply_system_colors(
-		struct wlf_color palette[WLF_THEME_COLOR_COUNT],
-		enum wlf_theme_appearance appearance) {
+		struct wlf_color palette[WLF_THEME_COLOR_COUNT]) {
 	@autoreleasepool {
 		[NSApplication sharedApplication];
 
-		palette[WLF_THEME_COLOR_ACCENT] = macos_theme_color_from_nscolor(
-			NSColor.controlAccentColor,
-			appearance,
-			palette[WLF_THEME_COLOR_ACCENT]);
 		palette[WLF_THEME_COLOR_HIGHLIGHT] =
 			macos_theme_color_from_nscolor_current(
 				NSColor.selectedContentBackgroundColor,
 				palette[WLF_THEME_COLOR_HIGHLIGHT]);
-		palette[WLF_THEME_COLOR_HIGHLIGHTED_TEXT] =
-			macos_theme_color_from_nscolor_current(
-				NSColor.alternateSelectedControlTextColor,
-				palette[WLF_THEME_COLOR_HIGHLIGHTED_TEXT]);
 	}
 }
 
@@ -163,15 +108,13 @@ static bool macos_theme_highlight_changed(
 		const struct wlf_color new_palette[WLF_THEME_COLOR_COUNT]) {
 	return memcmp(&old_palette[WLF_THEME_COLOR_HIGHLIGHT],
 			&new_palette[WLF_THEME_COLOR_HIGHLIGHT],
-			sizeof(struct wlf_color)) != 0 ||
-		memcmp(&old_palette[WLF_THEME_COLOR_HIGHLIGHTED_TEXT],
-			&new_palette[WLF_THEME_COLOR_HIGHLIGHTED_TEXT],
 			sizeof(struct wlf_color)) != 0;
 }
 
 void wlf_macos_theme_reload(struct wlf_macos_theme *theme) {
 	enum wlf_theme_appearance appearance;
 	struct wlf_color palette[WLF_THEME_COLOR_COUNT];
+	bool appearance_changed;
 	bool highlight_changed;
 
 	if (theme == NULL) {
@@ -179,71 +122,34 @@ void wlf_macos_theme_reload(struct wlf_macos_theme *theme) {
 	}
 
 	appearance = macos_theme_detect_appearance();
-	macos_theme_fill_palette(palette, appearance);
+	macos_theme_fill_palette(palette);
 	if (appearance == theme->base.appearance &&
 			memcmp(theme->palette, palette, sizeof(palette)) == 0) {
 		return;
 	}
 
+	appearance_changed = appearance != theme->base.appearance;
 	highlight_changed = macos_theme_highlight_changed(theme->palette, palette);
 	theme->base.appearance = appearance;
 	memcpy(theme->palette, palette, sizeof(palette));
-	wlf_signal_emit_mutable(&theme->base.events.theme_changed, &theme->base);
+	if (appearance_changed) {
+		wlf_signal_emit_mutable(&theme->base.events.theme_changed,
+			&theme->base);
+	}
 	if (highlight_changed) {
 		wlf_signal_emit_mutable(&theme->base.events.highlight_changed,
 			&theme->base);
 	}
 }
 
-static void macos_theme_fill_palette(struct wlf_color palette[WLF_THEME_COLOR_COUNT],
-		enum wlf_theme_appearance appearance) {
-	static const struct wlf_color light_palette[WLF_THEME_COLOR_COUNT] = {
-		[WLF_THEME_COLOR_WINDOW] = {1.0, 1.0, 1.0, 1.0},
-		[WLF_THEME_COLOR_WINDOW_TEXT] = {0.11, 0.11, 0.12, 1.0},
-		[WLF_THEME_COLOR_BASE] = {0.97, 0.97, 0.98, 1.0},
-		[WLF_THEME_COLOR_ALTERNATE_BASE] = {0.92, 0.93, 0.95, 1.0},
-		[WLF_THEME_COLOR_TEXT] = {0.11, 0.11, 0.12, 1.0},
-		[WLF_THEME_COLOR_BUTTON] = {0.95, 0.95, 0.96, 1.0},
-		[WLF_THEME_COLOR_BUTTON_TEXT] = {0.11, 0.11, 0.12, 1.0},
-		[WLF_THEME_COLOR_BORDER] = {0.80, 0.80, 0.82, 1.0},
-		[WLF_THEME_COLOR_SEPARATOR] = {0.84, 0.84, 0.86, 1.0},
-		[WLF_THEME_COLOR_PLACEHOLDER_TEXT] = {0.45, 0.45, 0.48, 1.0},
-		[WLF_THEME_COLOR_ACCENT] = {0.00, 0.48, 1.0, 1.0},
+static void macos_theme_fill_palette(
+		struct wlf_color palette[WLF_THEME_COLOR_COUNT]) {
+	static const struct wlf_color fallback_palette[WLF_THEME_COLOR_COUNT] = {
 		[WLF_THEME_COLOR_HIGHLIGHT] = {0.00, 0.35, 0.82, 1.0},
-		[WLF_THEME_COLOR_HIGHLIGHTED_TEXT] = {1.0, 1.0, 1.0, 1.0},
-		[WLF_THEME_COLOR_LINK] = {0.00, 0.40, 0.87, 1.0},
-		[WLF_THEME_COLOR_VISITED_LINK] = {0.44, 0.27, 0.68, 1.0},
-		[WLF_THEME_COLOR_MARK] = {1.0, 0.93, 0.60, 1.0},
-		[WLF_THEME_COLOR_SUCCESS] = {0.18, 0.69, 0.31, 1.0},
-		[WLF_THEME_COLOR_WARNING] = {1.0, 0.62, 0.04, 1.0},
-		[WLF_THEME_COLOR_ERROR] = {1.0, 0.23, 0.19, 1.0},
 	};
-	static const struct wlf_color dark_palette[WLF_THEME_COLOR_COUNT] = {
-		[WLF_THEME_COLOR_WINDOW] = {0.11, 0.11, 0.12, 1.0},
-		[WLF_THEME_COLOR_WINDOW_TEXT] = {0.93, 0.93, 0.94, 1.0},
-		[WLF_THEME_COLOR_BASE] = {0.16, 0.16, 0.17, 1.0},
-		[WLF_THEME_COLOR_ALTERNATE_BASE] = {0.20, 0.20, 0.22, 1.0},
-		[WLF_THEME_COLOR_TEXT] = {0.93, 0.93, 0.94, 1.0},
-		[WLF_THEME_COLOR_BUTTON] = {0.19, 0.19, 0.20, 1.0},
-		[WLF_THEME_COLOR_BUTTON_TEXT] = {0.93, 0.93, 0.94, 1.0},
-		[WLF_THEME_COLOR_BORDER] = {0.31, 0.31, 0.34, 1.0},
-		[WLF_THEME_COLOR_SEPARATOR] = {0.27, 0.27, 0.29, 1.0},
-		[WLF_THEME_COLOR_PLACEHOLDER_TEXT] = {0.58, 0.58, 0.61, 1.0},
-		[WLF_THEME_COLOR_ACCENT] = {0.04, 0.52, 1.0, 1.0},
-		[WLF_THEME_COLOR_HIGHLIGHT] = {0.00, 0.35, 0.82, 1.0},
-		[WLF_THEME_COLOR_HIGHLIGHTED_TEXT] = {1.0, 1.0, 1.0, 1.0},
-		[WLF_THEME_COLOR_LINK] = {0.35, 0.67, 1.0, 1.0},
-		[WLF_THEME_COLOR_VISITED_LINK] = {0.67, 0.51, 0.96, 1.0},
-		[WLF_THEME_COLOR_MARK] = {0.47, 0.38, 0.03, 1.0},
-		[WLF_THEME_COLOR_SUCCESS] = {0.19, 0.82, 0.35, 1.0},
-		[WLF_THEME_COLOR_WARNING] = {1.0, 0.74, 0.10, 1.0},
-		[WLF_THEME_COLOR_ERROR] = {1.0, 0.41, 0.38, 1.0},
-	};
-	const struct wlf_color *source = appearance == WLF_THEME_APPEARANCE_DARK ?
-		dark_palette : light_palette;
 
-	memcpy(palette, source, sizeof(light_palette));
-	macos_theme_apply_system_colors(palette, appearance);
+	memcpy(palette, fallback_palette, sizeof(fallback_palette));
+	macos_theme_apply_system_colors(palette);
 }
 
 @implementation WLFMacOSThemeObserver {
@@ -351,7 +257,7 @@ struct wlf_macos_theme *wlf_macos_theme_create(void) {
 
 	wlf_theme_init(&theme->base, &macos_theme_impl);
 	theme->base.appearance = macos_theme_detect_appearance();
-	macos_theme_fill_palette(theme->palette, theme->base.appearance);
+	macos_theme_fill_palette(theme->palette);
 	macos_theme_register_observer(theme);
 
 	return theme;

--- a/platform/wlf_theme.c
+++ b/platform/wlf_theme.c
@@ -53,6 +53,17 @@ void wlf_theme_destroy(struct wlf_theme *theme) {
 	}
 }
 
+const char *wlf_theme_appearance_name(
+		enum wlf_theme_appearance appearance) {
+	switch (appearance) {
+	case WLF_THEME_APPEARANCE_DARK:
+		return "dark";
+	case WLF_THEME_APPEARANCE_LIGHT:
+	default:
+		return "light";
+	}
+}
+
 struct wlf_color wlf_theme_palette_color(struct wlf_theme *theme,
 		enum wlf_theme_color_role role) {
 	return theme->impl->theme_palette_color(theme, role);


### PR DESCRIPTION
Only emit theme_changed when the resolved appearance switches between light and dark, and emit highlight_changed only when the system highlight color changes.

Drop WLF_THEME_COLOR_HIGHLIGHTED_TEXT since it is unused, and keep the macOS theme palette focused on the roles we actually expose.