### PR TITLE
build: fix Windows CI

### DIFF
--- a/.github/workflows/windows-build.yaml
+++ b/.github/workflows/windows-build.yaml
@@ -55,8 +55,13 @@ jobs:
           ${{ runner.os }}-vcpkg-${{ env.VCPKG_TRIPLET }}-${{ steps.vcpkg_revision.outputs.revision }}-
           ${{ runner.os }}-vcpkg-${{ env.VCPKG_TRIPLET }}-
 
+    - name: Prepare vcpkg binary cache
+      run: |
+        New-Item -ItemType Directory -Force -Path $env:VCPKG_DEFAULT_BINARY_CACHE | Out-Null
+
     - name: Install dependencies
       run: |
+        Remove-Item Env:VCPKG_ROOT -ErrorAction SilentlyContinue
         & "$env:WLF_VCPKG_ROOT\vcpkg.exe" install `
           libpng `
           libjpeg-turbo `

--- a/.github/workflows/windows-build.yaml
+++ b/.github/workflows/windows-build.yaml
@@ -9,6 +9,8 @@ env:
   BUILD_TYPE: debug
   WLF_VCPKG_ROOT: ${{ github.workspace }}\vcpkg
   VCPKG_TRIPLET: x64-windows
+  VCPKG_DEFAULT_BINARY_CACHE: ${{ github.workspace }}\.vcpkg-binary-cache
+  VCPKG_BINARY_SOURCES: clear;files,${{ github.workspace }}\.vcpkg-binary-cache,readwrite
 
 jobs:
   build-windows:
@@ -36,6 +38,22 @@ jobs:
           git clone https://github.com/microsoft/vcpkg.git "$env:WLF_VCPKG_ROOT"
         }
         & "$env:WLF_VCPKG_ROOT\bootstrap-vcpkg.bat" -disableMetrics
+
+    - name: Capture vcpkg revision
+      id: vcpkg_revision
+      run: |
+        $revision = (& git -C "$env:WLF_VCPKG_ROOT" rev-parse HEAD).Trim()
+        "revision=$revision" >> $env:GITHUB_OUTPUT
+
+    - name: Cache vcpkg binary packages
+      uses: actions/cache@v4
+      with:
+        path: ${{ env.VCPKG_DEFAULT_BINARY_CACHE }}
+        # The dependency list is kept in this workflow because vcpkg classic mode is used.
+        key: ${{ runner.os }}-vcpkg-${{ env.VCPKG_TRIPLET }}-${{ steps.vcpkg_revision.outputs.revision }}-${{ hashFiles('.github/workflows/windows-build.yaml') }}
+        restore-keys: |
+          ${{ runner.os }}-vcpkg-${{ env.VCPKG_TRIPLET }}-${{ steps.vcpkg_revision.outputs.revision }}-
+          ${{ runner.os }}-vcpkg-${{ env.VCPKG_TRIPLET }}-
 
     - name: Install dependencies
       run: |

--- a/pass/wlf_shape_geometry.c
+++ b/pass/wlf_shape_geometry.c
@@ -39,9 +39,12 @@ void wlf_shape_add_triangle_coverage(struct wlf_shape_vertices *vertices,
 		double ax, double ay, float ac, double bx, double by, float bc,
 		double cx, double cy, float cc) {
 	if (!reserve(vertices, 3)) return;
-	vertices->data[vertices->len++] = (struct wlf_vector_vertex){ ax, ay, ac };
-	vertices->data[vertices->len++] = (struct wlf_vector_vertex){ bx, by, bc };
-	vertices->data[vertices->len++] = (struct wlf_vector_vertex){ cx, cy, cc };
+	vertices->data[vertices->len++] =
+		(struct wlf_vector_vertex){ (float)ax, (float)ay, ac };
+	vertices->data[vertices->len++] =
+		(struct wlf_vector_vertex){ (float)bx, (float)by, bc };
+	vertices->data[vertices->len++] =
+		(struct wlf_vector_vertex){ (float)cx, (float)cy, cc };
 }
 
 void wlf_shape_add_quad(struct wlf_shape_vertices *vertices,
@@ -236,8 +239,10 @@ int wlf_shape_rounded_rect_points(const struct wlf_rect_shape *rect,
 		for (int i = 0; i <= corner_segments; i++) {
 			double angle = starts[corner] +
 				(double)i / corner_segments * WLF_PI / 2;
-			points[count * 2] = centers[corner][0] + cos(angle) * rx;
-			points[count * 2 + 1] = centers[corner][1] + sin(angle) * ry;
+			points[count * 2] =
+				(float)(centers[corner][0] + cos(angle) * rx);
+			points[count * 2 + 1] =
+				(float)(centers[corner][1] + sin(angle) * ry);
 			count++;
 		}
 	}

--- a/scene/wlf_scene.c
+++ b/scene/wlf_scene.c
@@ -334,7 +334,7 @@ static void handle_window_expose(struct wlf_listener *listener, void *data) {
 	}
 
 	struct timespec now;
-	clock_gettime(CLOCK_MONOTONIC, &now);
+	wlf_get_monotonic_time(&now);
 	wlf_scene_send_frame_done(scene, &now);
 }
 

--- a/scene/wlf_svg_node.c
+++ b/scene/wlf_svg_node.c
@@ -155,27 +155,33 @@ static struct wlf_scene_node *create_geometry_node(
 	struct wlf_scene_node *node = NULL;
 	if (wlf_shape_is_rect(geometry)) {
 		struct wlf_rect_shape_node *rect = wlf_rect_shape_node_create(
-			&svg_node->base, x, y, wlf_rect_shape_from_shape(geometry));
+			&svg_node->base, (int)x, (int)y,
+			wlf_rect_shape_from_shape(geometry));
 		node = rect != NULL ? &rect->base : NULL;
 	} else if (wlf_shape_is_circle(geometry)) {
 		struct wlf_circle_node *circle = wlf_circle_node_create(
-			&svg_node->base, x, y, wlf_circle_shape_from_shape(geometry));
+			&svg_node->base, (int)x, (int)y,
+			wlf_circle_shape_from_shape(geometry));
 		node = circle != NULL ? &circle->base : NULL;
 	} else if (wlf_shape_is_ellipse(geometry)) {
 		struct wlf_ellipse_node *ellipse = wlf_ellipse_node_create(
-			&svg_node->base, x, y, wlf_ellipse_shape_from_shape(geometry));
+			&svg_node->base, (int)x, (int)y,
+			wlf_ellipse_shape_from_shape(geometry));
 		node = ellipse != NULL ? &ellipse->base : NULL;
 	} else if (wlf_shape_is_line(geometry)) {
 		struct wlf_line_node *line = wlf_line_node_create(
-			&svg_node->base, x, y, wlf_line_shape_from_shape(geometry));
+			&svg_node->base, (int)x, (int)y,
+			wlf_line_shape_from_shape(geometry));
 		node = line != NULL ? &line->base : NULL;
 	} else if (wlf_shape_is_poly(geometry)) {
 		struct wlf_poly_node *poly = wlf_poly_node_create(
-			&svg_node->base, x, y, wlf_poly_shape_from_shape(geometry));
+			&svg_node->base, (int)x, (int)y,
+			wlf_poly_shape_from_shape(geometry));
 		node = poly != NULL ? &poly->base : NULL;
 	} else if (wlf_shape_is_path(geometry)) {
 		struct wlf_path_node *path = wlf_path_node_create(
-			&svg_node->base, x, y, wlf_path_shape_from_shape(geometry));
+			&svg_node->base, (int)x, (int)y,
+			wlf_path_shape_from_shape(geometry));
 		node = path != NULL ? &path->base : NULL;
 	}
 
@@ -199,7 +205,7 @@ static struct wlf_scene_node *create_text_node(struct wlf_svg_node *svg_node,
 	}
 
 	struct wlf_text_node *text = wlf_text_node_create(&svg_node->base,
-		shape->x, shape->y, shape->text, shape->font_family,
+		(int)shape->x, (int)shape->y, shape->text, shape->font_family,
 		shape->font_size, &color);
 	if (text == NULL) {
 		return NULL;
@@ -211,7 +217,8 @@ static struct wlf_scene_node *create_text_node(struct wlf_svg_node *svg_node,
 	} else if (shape->text_anchor == WLF_TEXT_ANCHOR_END) {
 		x -= text->natural_width;
 	}
-	wlf_scene_node_set_position(&text->base, x, shape->y - text->baseline);
+	wlf_scene_node_set_position(&text->base, (int)x,
+		(int)(shape->y - text->baseline));
 	return &text->base;
 }
 

--- a/texture/wlf_texture.c
+++ b/texture/wlf_texture.c
@@ -135,6 +135,10 @@ struct wlf_texture *wlf_texture_from_image(struct wlf_renderer *renderer,
 		return NULL;
 	}
 	size_t rgba_stride = width * 4;
+	if (rgba_stride > UINT32_MAX) {
+		wlf_log(WLF_ERROR, "image row stride is too large");
+		return NULL;
+	}
 	if (image->height > SIZE_MAX / rgba_stride) {
 		wlf_log(WLF_ERROR, "image dimensions are too large");
 		return NULL;
@@ -213,7 +217,8 @@ struct wlf_texture *wlf_texture_from_image(struct wlf_renderer *renderer,
 	}
 
 	struct wlf_texture *texture = wlf_texture_from_pixels(renderer,
-		WLF_FORMAT_ABGR8888, rgba_stride, image->width, image->height, rgba);
+		WLF_FORMAT_ABGR8888, (uint32_t)rgba_stride,
+		image->width, image->height, rgba);
 	free(rgba);
 	return texture;
 }


### PR DESCRIPTION
fix MSVC build failures caused by implicit narrowing conversions and non-portable monotonic clock usage.

add explicit casts for geometry and image stride values, and use the platform-independent monotonic time helper for scene frame timestamps.