### PR TITLE
text: add a platform-independent text rendering interface

### DIFF
--- a/.github/workflows/macos-build.yaml
+++ b/.github/workflows/macos-build.yaml
@@ -43,9 +43,6 @@ jobs:
           libxml2 \
           webp \
           giflib \
-          cairo \
-          pango \
-          harfbuzz \
           pixman \
 
     - name: Setup build

--- a/.github/workflows/windows-build.yaml
+++ b/.github/workflows/windows-build.yaml
@@ -68,9 +68,6 @@ jobs:
           libwebp `
           giflib `
           pixman `
-          cairo `
-          pango `
-          harfbuzz `
           pkgconf `
           --triplet $env:VCPKG_TRIPLET
 

--- a/include/wlf/platform/linux/text.h
+++ b/include/wlf/platform/linux/text.h
@@ -1,0 +1,32 @@
+/**
+ * @file        text.h
+ * @brief       Linux text implementation for wlframe.
+ * @details     Declares the Linux Cairo/Pango/HarfBuzz text implementation used by
+ *              the platform-independent text interface.
+ * @author      YaoBing Xiao
+ * @date        2026-08-12
+ * @version     v1.0
+ * @par Copyright(c):
+ * @par History:
+ *      version: v1.0, YaoBing Xiao, 2026-08-12, initial version\n
+ */
+
+#ifndef LINUX_TEXT_H
+#define LINUX_TEXT_H
+
+#include "wlf/platform/wlf_text.h"
+
+/**
+ * @brief Linux text object.
+ */
+struct wlf_linux_text {
+	struct wlf_text base; /**< Platform-independent text object. */
+};
+
+/**
+ * @brief Create the Linux Cairo/Pango/HarfBuzz text implementation.
+ * @return A newly allocated text object, or NULL on allocation failure.
+ */
+struct wlf_linux_text *wlf_linux_text_create(void);
+
+#endif // LINUX_TEXT_H

--- a/include/wlf/platform/wlf_text.h
+++ b/include/wlf/platform/wlf_text.h
@@ -1,0 +1,160 @@
+/**
+ * @file        wlf_text.h
+ * @brief       Cross-platform text shaping and rasterization interface.
+ * @details     The scene layer uses this interface without depending on a
+ *              particular text stack. Platform implementations provide shaped text
+ *              metrics and premultiplied ARGB8888 pixels for texture upload.
+ * @author      YaoBing Xiao
+ * @date        2026-08-12
+ * @version     v1.0
+ * @par Copyright(c):
+ * @par History:
+ *      version: v1.0, YaoBing Xiao, 2026-08-12, initial version\n
+ */
+
+#ifndef PLATFORM_WLF_TEXT_H
+#define PLATFORM_WLF_TEXT_H
+
+#include "wlf/types/wlf_color.h"
+
+#include <stdbool.h>
+#include <stdint.h>
+
+/**
+ * @brief Font slant requested from a text implementation.
+ */
+enum wlf_text_font_slant {
+	WLF_TEXT_FONT_SLANT_NORMAL, /**< Upright glyphs. */
+	WLF_TEXT_FONT_SLANT_ITALIC, /**< Designed italic glyphs. */
+	WLF_TEXT_FONT_SLANT_OBLIQUE, /**< Obliquely slanted glyphs. */
+};
+
+/**
+ * @brief Font weight requested from a text implementation.
+ */
+enum wlf_text_font_weight {
+	WLF_TEXT_FONT_WEIGHT_NORMAL, /**< Normal weight. */
+	WLF_TEXT_FONT_WEIGHT_BOLD, /**< Bold weight. */
+};
+
+/**
+ * @brief Text shaping and rasterization options.
+ *
+ * The text is UTF-8 encoded. A negative maximum width disables clipping;
+ * zero also disables clipping and is kept as a convenient public API value.
+ */
+struct wlf_text_options {
+	const char *text; /**< UTF-8 text to shape. */
+	const char *font_family; /**< Requested family, or NULL for sans-serif. */
+	double font_size; /**< Font size in logical units. */
+	double raster_scale; /**< Device scale used for rasterization. */
+	struct wlf_color color; /**< Text color. */
+	int max_width; /**< Maximum logical width, or a non-positive value for none. */
+	enum wlf_text_font_slant slant; /**< Requested font slant. */
+	enum wlf_text_font_weight weight; /**< Requested font weight. */
+};
+
+/**
+ * @brief Geometric metrics returned by a text implementation.
+ *
+ * The bounds are expressed in raster pixels. The baseline is measured from
+ * the top of the returned bounds and is also expressed in raster pixels.
+ */
+struct wlf_text_metrics {
+	double left; /**< Left edge of the union of ink and logical bounds. */
+	double top; /**< Top edge of the union of ink and logical bounds. */
+	double width; /**< Natural text width in raster pixels. */
+	double height; /**< Text height in raster pixels. */
+	double baseline; /**< Baseline offset from the top of the bounds. */
+};
+
+/**
+ * @brief Rasterized text returned by a text implementation.
+ *
+ * @p data remains owned by the text implementation and is valid until
+ * wlf_text_raster_destroy() is called. Empty text may return zero dimensions
+ * and a NULL data pointer while still providing valid metrics.
+ */
+struct wlf_text_raster {
+	struct wlf_text_metrics metrics; /**< Natural shaped text metrics. */
+	uint32_t width; /**< Raster width in pixels after clipping. */
+	uint32_t height; /**< Raster height in pixels. */
+	uint32_t stride; /**< Raster row stride in bytes. */
+	const void *data; /**< Premultiplied ARGB8888 pixel data. */
+	void *private_data; /**< Opaque storage owned by the text implementation. */
+};
+
+struct wlf_text;
+
+/**
+ * @brief Virtual methods implemented by a platform text implementation.
+ */
+
+struct wlf_text_impl {
+	const char *name; /**< Human-readable implementation name. */
+	bool (*rasterize)(struct wlf_text *text,
+		const struct wlf_text_options *options,
+		struct wlf_text_raster *raster); /**< Shape and rasterize text. */
+	void (*destroy_raster)(struct wlf_text *text,
+		struct wlf_text_raster *raster); /**< Release raster-owned resources. */
+	void (*destroy)(struct wlf_text *text); /**< Destroy the text implementation. */
+};
+
+/**
+ * @brief Platform-independent text object.
+ */
+struct wlf_text {
+	const struct wlf_text_impl *impl; /**< Text implementation methods. */
+};
+
+/**
+ * @brief Initialize a text object with its implementation table.
+ * @param text Text object to initialize.
+ * @param impl Implementation table supplied by a platform implementation.
+ */
+void wlf_text_init(struct wlf_text *text, const struct wlf_text_impl *impl);
+
+/**
+ * @brief Create the text implementation for the current platform.
+ *
+ * Linux currently uses the Cairo/Pango/HarfBuzz implementation. The native
+ * Core Text and DirectWrite implementations are reserved for later work, so
+ * this function returns NULL on macOS and Windows for now.
+ *
+ * @return A newly allocated text object, or NULL when no implementation is available.
+ */
+struct wlf_text *wlf_text_autocreate(void);
+
+/**
+ * @brief Destroy a text object.
+ * @param text Text object to destroy. NULL is allowed.
+ */
+void wlf_text_destroy(struct wlf_text *text);
+
+/**
+ * @brief Shape and rasterize text through a text implementation.
+ * @param text Text object to use.
+ * @param options Text shaping and rasterization options.
+ * @param raster Output raster and metrics.
+ * @return true on success, false on invalid input or implementation failure.
+ */
+bool wlf_text_rasterize(struct wlf_text *text,
+	const struct wlf_text_options *options,
+	struct wlf_text_raster *raster);
+
+/**
+ * @brief Release a raster returned by wlf_text_rasterize().
+ * @param text Text object that produced the raster.
+ * @param raster Raster to release. NULL is allowed.
+ */
+void wlf_text_raster_destroy(struct wlf_text *text,
+	struct wlf_text_raster *raster);
+
+/**
+ * @brief Check whether a string is valid UTF-8.
+ * @param text NUL-terminated string to check.
+ * @return true for valid UTF-8, false for NULL or malformed input.
+ */
+bool wlf_text_is_valid_utf8(const char *text);
+
+#endif // PLATFORM_WLF_TEXT_H

--- a/include/wlf/scene/wlf_text_node.h
+++ b/include/wlf/scene/wlf_text_node.h
@@ -15,31 +15,15 @@
 #define SCENE_WLF_TEXT_NODE_H
 
 #include "wlf/pass/wlf_texture_pass.h"
+#include "wlf/platform/wlf_text.h"
 #include "wlf/scene/wlf_scene_node.h"
 #include "wlf/texture/wlf_texture.h"
 #include "wlf/types/wlf_color.h"
 
 /**
- * @brief Font slant used when rasterizing a text node.
- */
-enum wlf_text_font_slant {
-	WLF_TEXT_FONT_SLANT_NORMAL, /**< Upright glyphs. */
-	WLF_TEXT_FONT_SLANT_ITALIC, /**< Designed italic glyphs. */
-	WLF_TEXT_FONT_SLANT_OBLIQUE, /**< Obliquely slanted glyphs. */
-};
-
-/**
- * @brief Font weight used when rasterizing a text node.
- */
-enum wlf_text_font_weight {
-	WLF_TEXT_FONT_WEIGHT_NORMAL, /**< Normal weight. */
-	WLF_TEXT_FONT_WEIGHT_BOLD, /**< Bold weight. */
-};
-
-/**
  * @brief A scene node containing rasterized UTF-8 text.
  *
- * Text is shaped with Pango/HarfBuzz and rasterized with Cairo into a
+ * Text is shaped and rasterized through the platform text implementation into a
  * renderer texture owned by the node.
  */
 struct wlf_text_node {
@@ -54,6 +38,7 @@ struct wlf_text_node {
 	double raster_scale;
 	enum wlf_text_font_slant font_slant;
 	enum wlf_text_font_weight font_weight;
+	struct wlf_text *text_context;
 	struct wlf_renderer *renderer;
 	struct wlf_texture *texture;
 	struct wlf_listener renderer_destroy;

--- a/meson.build
+++ b/meson.build
@@ -169,12 +169,6 @@ elif is_macos
 	libwebp = dependency('libwebp', required: true, method: 'pkg-config')
 	libwebpdemux = dependency('libwebpdemux', required: true, method: 'pkg-config')
 	libwebpmux = dependency('libwebpmux', required: true, method: 'pkg-config')
-	cairo = dependency('cairo', version: '>=1.16', required: true,
-		method: 'pkg-config')
-	pangocairo = dependency('pangocairo', version: '>=1.44', required: true,
-		method: 'pkg-config')
-	harfbuzz = dependency('harfbuzz', version: '>=2.6', required: true,
-		method: 'pkg-config')
 	pixman = dependency('pixman-1', version: '>=0.42', required: true, method: 'pkg-config')
 	brew = find_program('brew', required: false)
 	if not brew.found()
@@ -218,9 +212,6 @@ elif is_windows
 	libwebp = dependency('libwebp', required: true)
 	libwebpdemux = dependency('libwebpdemux', required: true)
 	libwebpmux = dependency('libwebpmux', required: true)
-	cairo = dependency('cairo', version: '>=1.16', required: true)
-	pangocairo = dependency('pangocairo', version: '>=1.44', required: true)
-	harfbuzz = dependency('harfbuzz', version: '>=2.6', required: true)
 	pixman = dependency('pixman-1', version: '>=0.42', required: true)
 	giflib = dependency('giflib', required: false)
 	if not giflib.found()
@@ -246,9 +237,6 @@ wlf_deps = [
 	libwebpmux,
 	giflib,
 	pixman,
-	cairo,
-	pangocairo,
-	harfbuzz,
 ]
 
 if is_macos
@@ -271,6 +259,9 @@ elif is_linux
 		wayland_egl,
 		egl,
 		gio,
+		cairo,
+		pangocairo,
+		harfbuzz,
 	]
 elif is_windows
 	wlf_deps += [

--- a/platform/linux/meson.build
+++ b/platform/linux/meson.build
@@ -1,3 +1,4 @@
 wlf_files += files(
 	'theme.c',
+	'text.c',
 )

--- a/platform/linux/text.c
+++ b/platform/linux/text.c
@@ -1,0 +1,202 @@
+#include "wlf/platform/linux/text.h"
+
+#include "wlf/utils/wlf_log.h"
+
+#include <cairo/cairo.h>
+#include <limits.h>
+#include <math.h>
+#include <pango/pangocairo.h>
+#include <stdlib.h>
+
+static PangoStyle to_pango_style(enum wlf_text_font_slant slant) {
+	switch (slant) {
+	case WLF_TEXT_FONT_SLANT_ITALIC:
+		return PANGO_STYLE_ITALIC;
+	case WLF_TEXT_FONT_SLANT_OBLIQUE:
+		return PANGO_STYLE_OBLIQUE;
+	case WLF_TEXT_FONT_SLANT_NORMAL:
+	default:
+		return PANGO_STYLE_NORMAL;
+	}
+}
+
+static PangoWeight to_pango_weight(enum wlf_text_font_weight weight) {
+	return weight == WLF_TEXT_FONT_WEIGHT_BOLD ?
+		PANGO_WEIGHT_BOLD : PANGO_WEIGHT_NORMAL;
+}
+
+static PangoLayout *create_layout(cairo_t *cr,
+		const struct wlf_text_options *options) {
+	PangoLayout *layout = pango_cairo_create_layout(cr);
+	if (layout == NULL) {
+		return NULL;
+	}
+
+	PangoFontDescription *font = pango_font_description_new();
+	if (font == NULL) {
+		g_object_unref(layout);
+		return NULL;
+	}
+
+	double pixel_size = options->font_size * options->raster_scale;
+	if (!isfinite(pixel_size) || pixel_size <= 0 ||
+			pixel_size > INT_MAX / (double)PANGO_SCALE) {
+		pango_font_description_free(font);
+		g_object_unref(layout);
+		return NULL;
+	}
+
+	pango_font_description_set_family(font,
+		options->font_family != NULL ? options->font_family : "sans-serif");
+	pango_font_description_set_absolute_size(font,
+		pixel_size * PANGO_SCALE);
+	pango_font_description_set_style(font, to_pango_style(options->slant));
+	pango_font_description_set_weight(font, to_pango_weight(options->weight));
+	pango_layout_set_font_description(layout, font);
+	pango_font_description_free(font);
+
+	pango_layout_set_text(layout, options->text, -1);
+	pango_layout_set_auto_dir(layout, true);
+	return layout;
+}
+
+static void measure_layout(PangoLayout *layout,
+		struct wlf_text_metrics *metrics) {
+	PangoRectangle ink;
+	PangoRectangle logical;
+	pango_layout_get_pixel_extents(layout, &ink, &logical);
+
+	int left = MIN(0, MIN(ink.x, logical.x));
+	int top = MIN(0, MIN(ink.y, logical.y));
+	int right = MAX(ink.x + ink.width, logical.x + logical.width);
+	int bottom = MAX(ink.y + ink.height, logical.y + logical.height);
+	*metrics = (struct wlf_text_metrics){
+		.left = left,
+		.top = top,
+		.width = right - left,
+		.height = bottom - top,
+		.baseline = pango_layout_get_baseline(layout) /
+			(double)PANGO_SCALE - top,
+	};
+}
+
+static void linux_text_raster_destroy(struct wlf_text *text,
+		struct wlf_text_raster *raster) {
+	(void)text;
+	if (raster->private_data != NULL) {
+		cairo_surface_destroy(raster->private_data);
+	}
+	*raster = (struct wlf_text_raster){0};
+}
+
+static bool linux_text_rasterize(struct wlf_text *text,
+		const struct wlf_text_options *options,
+		struct wlf_text_raster *raster) {
+	(void)text;
+
+	cairo_surface_t *measure_surface = cairo_image_surface_create(
+		CAIRO_FORMAT_ARGB32, 1, 1);
+	if (cairo_surface_status(measure_surface) != CAIRO_STATUS_SUCCESS) {
+		cairo_surface_destroy(measure_surface);
+		return false;
+	}
+	cairo_t *measure = cairo_create(measure_surface);
+	PangoLayout *layout = create_layout(measure, options);
+	struct wlf_text_metrics metrics = {0};
+	if (layout != NULL) {
+		measure_layout(layout, &metrics);
+	}
+	bool measured = layout != NULL &&
+		cairo_status(measure) == CAIRO_STATUS_SUCCESS;
+	cairo_destroy(measure);
+	cairo_surface_destroy(measure_surface);
+	if (!measured || metrics.width < 0 || metrics.height < 0 ||
+			metrics.width > INT32_MAX || metrics.height > INT32_MAX) {
+		if (layout != NULL) {
+			g_object_unref(layout);
+		}
+		return false;
+	}
+
+	raster->metrics = metrics;
+	if (options->text[0] == '\0' || metrics.width <= 0 ||
+			metrics.height <= 0) {
+		g_object_unref(layout);
+		return true;
+	}
+
+	int width = (int)metrics.width;
+	int height = (int)metrics.height;
+	if (options->max_width > 0) {
+		double max_pixel_width = options->max_width * options->raster_scale;
+		if (!isfinite(max_pixel_width) || max_pixel_width < 0) {
+			g_object_unref(layout);
+			return false;
+		}
+		if (max_pixel_width < width) {
+			width = (int)ceil(max_pixel_width);
+		}
+	}
+	if (width <= 0 || height <= 0) {
+		g_object_unref(layout);
+		return true;
+	}
+
+	cairo_surface_t *surface = cairo_image_surface_create(
+		CAIRO_FORMAT_ARGB32, width, height);
+	if (cairo_surface_status(surface) != CAIRO_STATUS_SUCCESS) {
+		wlf_log(WLF_ERROR, "failed to create Cairo text surface: %s",
+			cairo_status_to_string(cairo_surface_status(surface)));
+		g_object_unref(layout);
+		cairo_surface_destroy(surface);
+		return false;
+	}
+
+	cairo_t *cr = cairo_create(surface);
+	cairo_set_operator(cr, CAIRO_OPERATOR_CLEAR);
+	cairo_paint(cr);
+	cairo_set_operator(cr, CAIRO_OPERATOR_OVER);
+	struct wlf_color color = wlf_color_clamp(&options->color);
+	cairo_set_source_rgba(cr, color.r, color.g, color.b, color.a);
+	cairo_move_to(cr, -metrics.left, -metrics.top);
+	pango_cairo_update_layout(cr, layout);
+	pango_cairo_show_layout(cr, layout);
+	bool drawn = cairo_status(cr) == CAIRO_STATUS_SUCCESS;
+	g_object_unref(layout);
+	cairo_destroy(cr);
+	if (!drawn) {
+		wlf_log(WLF_ERROR, "failed to rasterize text node");
+		cairo_surface_destroy(surface);
+		return false;
+	}
+
+	cairo_surface_flush(surface);
+	raster->width = (uint32_t)width;
+	raster->height = (uint32_t)height;
+	raster->stride = (uint32_t)cairo_image_surface_get_stride(surface);
+	raster->data = cairo_image_surface_get_data(surface);
+	raster->private_data = surface;
+	return true;
+}
+
+static void linux_text_destroy(struct wlf_text *text) {
+	free(text);
+}
+
+static const struct wlf_text_impl linux_text_impl = {
+	.name = "linux-cairo-pango-harfbuzz",
+	.rasterize = linux_text_rasterize,
+	.destroy_raster = linux_text_raster_destroy,
+	.destroy = linux_text_destroy,
+};
+
+struct wlf_linux_text *wlf_linux_text_create(void) {
+	struct wlf_linux_text *text = calloc(1, sizeof(*text));
+	if (text == NULL) {
+		wlf_log_errno(WLF_ERROR, "failed to allocate Linux text implementation");
+		return NULL;
+	}
+
+	wlf_text_init(&text->base, &linux_text_impl);
+	return text;
+}

--- a/platform/meson.build
+++ b/platform/meson.build
@@ -2,6 +2,7 @@ wlf_files += files(
 	'wlf_backend.c',
 	'wlf_theme.c',
 	'wlf_fontconfig.c',
+	'wlf_text.c',
 )
 
 if is_linux

--- a/platform/wlf_text.c
+++ b/platform/wlf_text.c
@@ -1,0 +1,183 @@
+#include "wlf/platform/wlf_text.h"
+
+#include "wlf/config.h"
+
+#if WLF_HAS_LINUX_PLATFORM
+#include "wlf/platform/linux/text.h"
+#endif
+
+#include <assert.h>
+#include <math.h>
+#include <stdlib.h>
+#include <string.h>
+
+void wlf_text_init(struct wlf_text *text,
+		const struct wlf_text_impl *impl) {
+	assert(text != NULL);
+	assert(impl != NULL);
+	assert(impl->name != NULL);
+	assert(impl->rasterize != NULL);
+	assert(impl->destroy_raster != NULL);
+	assert(impl->destroy != NULL);
+
+	text->impl = impl;
+}
+
+struct wlf_text *wlf_text_autocreate(void) {
+#if WLF_HAS_LINUX_PLATFORM
+	struct wlf_linux_text *text = wlf_linux_text_create();
+	if (text == NULL) {
+		return NULL;
+	}
+
+	return &text->base;
+#else
+	/* Core Text and DirectWrite implementations will be selected here once they are
+	 * implemented. Keeping the selection in this module leaves scene code
+	 * independent of platform text libraries. */
+	return NULL;
+#endif
+}
+
+void wlf_text_destroy(struct wlf_text *text) {
+	if (text == NULL) {
+		return;
+	}
+
+	if (text->impl != NULL && text->impl->destroy != NULL) {
+		text->impl->destroy(text);
+	} else {
+		free(text);
+	}
+}
+
+bool wlf_text_rasterize(struct wlf_text *text,
+		const struct wlf_text_options *options,
+		struct wlf_text_raster *raster) {
+	if (raster == NULL) {
+		return false;
+	}
+	*raster = (struct wlf_text_raster){0};
+
+	if (text == NULL || text->impl == NULL || options == NULL ||
+			options->text == NULL || options->font_size <= 0 ||
+			!isfinite(options->font_size) || options->raster_scale <= 0 ||
+			!isfinite(options->raster_scale) ||
+			!wlf_text_is_valid_utf8(options->text)) {
+		return false;
+	}
+
+	if (!text->impl->rasterize(text, options, raster)) {
+		wlf_text_raster_destroy(text, raster);
+		return false;
+	}
+	return true;
+}
+
+void wlf_text_raster_destroy(struct wlf_text *text,
+		struct wlf_text_raster *raster) {
+	if (raster == NULL) {
+		return;
+	}
+
+	if (text != NULL && text->impl != NULL &&
+			text->impl->destroy_raster != NULL) {
+		text->impl->destroy_raster(text, raster);
+	} else {
+		*raster = (struct wlf_text_raster){0};
+	}
+}
+
+static bool utf8_continuation(unsigned char byte) {
+	return (byte & 0xc0) == 0x80;
+}
+
+bool wlf_text_is_valid_utf8(const char *text) {
+	if (text == NULL) {
+		return false;
+	}
+
+	const unsigned char *p = (const unsigned char *)text;
+	size_t length = strlen(text);
+	size_t offset = 0;
+	while (offset < length) {
+		unsigned char byte = p[offset];
+		if (byte < 0x80) {
+			offset++;
+			continue;
+		}
+
+		if (byte >= 0xc2 && byte <= 0xdf) {
+			if (length - offset < 2 ||
+					!utf8_continuation(p[offset + 1])) {
+				return false;
+			}
+			offset += 2;
+			continue;
+		}
+
+		if (byte == 0xe0) {
+			if (length - offset < 3 || p[offset + 1] < 0xa0 ||
+					p[offset + 1] > 0xbf ||
+					!utf8_continuation(p[offset + 2])) {
+				return false;
+			}
+			offset += 3;
+			continue;
+		}
+		if ((byte >= 0xe1 && byte <= 0xec) ||
+				(byte >= 0xee && byte <= 0xef)) {
+			if (length - offset < 3 ||
+					!utf8_continuation(p[offset + 1]) ||
+					!utf8_continuation(p[offset + 2])) {
+				return false;
+			}
+			offset += 3;
+			continue;
+		}
+		if (byte == 0xed) {
+			if (length - offset < 3 || p[offset + 1] < 0x80 ||
+					p[offset + 1] > 0x9f ||
+					!utf8_continuation(p[offset + 2])) {
+				return false;
+			}
+			offset += 3;
+			continue;
+		}
+
+		if (byte == 0xf0) {
+			if (length - offset < 4 || p[offset + 1] < 0x90 ||
+					p[offset + 1] > 0xbf ||
+					!utf8_continuation(p[offset + 2]) ||
+					!utf8_continuation(p[offset + 3])) {
+				return false;
+			}
+			offset += 4;
+			continue;
+		}
+		if (byte >= 0xf1 && byte <= 0xf3) {
+			if (length - offset < 4 ||
+					!utf8_continuation(p[offset + 1]) ||
+					!utf8_continuation(p[offset + 2]) ||
+					!utf8_continuation(p[offset + 3])) {
+				return false;
+			}
+			offset += 4;
+			continue;
+		}
+		if (byte == 0xf4) {
+			if (length - offset < 4 || p[offset + 1] < 0x80 ||
+					p[offset + 1] > 0x8f ||
+					!utf8_continuation(p[offset + 2]) ||
+					!utf8_continuation(p[offset + 3])) {
+				return false;
+			}
+			offset += 4;
+			continue;
+		}
+
+		return false;
+	}
+
+	return true;
+}

--- a/scene/wlf_text_node.c
+++ b/scene/wlf_text_node.c
@@ -1,5 +1,6 @@
 #include "wlf/scene/wlf_text_node.h"
 
+#include "wlf/platform/wlf_text.h"
 #include "wlf/scene/wlf_scene.h"
 #include "wlf/types/wlf_pixel_format.h"
 #include "wlf/utils/wlf_log.h"
@@ -7,39 +8,13 @@
 
 #include <assert.h>
 #include <math.h>
-#include <pango/pangocairo.h>
 #include <stdint.h>
 #include <stdlib.h>
 #include <string.h>
 
-struct text_metrics {
-	double left;
-	double top;
-	double width;
-	double height;
-	double baseline;
-};
-
 static void scene_node_render(struct wlf_render_list_entry *entry,
 	const struct wlf_render_data *data);
 static bool text_node_rasterize(struct wlf_text_node *node);
-
-static PangoStyle to_pango_style(enum wlf_text_font_slant slant) {
-	switch (slant) {
-	case WLF_TEXT_FONT_SLANT_ITALIC:
-		return PANGO_STYLE_ITALIC;
-	case WLF_TEXT_FONT_SLANT_OBLIQUE:
-		return PANGO_STYLE_OBLIQUE;
-	case WLF_TEXT_FONT_SLANT_NORMAL:
-	default:
-		return PANGO_STYLE_NORMAL;
-	}
-}
-
-static PangoWeight to_pango_weight(enum wlf_text_font_weight weight) {
-	return weight == WLF_TEXT_FONT_WEIGHT_BOLD ?
-		PANGO_WEIGHT_BOLD : PANGO_WEIGHT_NORMAL;
-}
 
 static bool text_node_invisible(struct wlf_scene_node *base) {
 	struct wlf_text_node *node = wlf_text_node_from_node(base);
@@ -144,88 +119,34 @@ static void handle_window_scale(struct wlf_listener *listener, void *data) {
 	}
 }
 
-static PangoLayout *create_layout(cairo_t *cr,
-		const struct wlf_text_node *node) {
-	PangoLayout *layout = pango_cairo_create_layout(cr);
-	if (layout == NULL) {
-		return NULL;
-	}
-
-	PangoFontDescription *font = pango_font_description_new();
-	if (font == NULL) {
-		g_object_unref(layout);
-		return NULL;
-	}
-	pango_font_description_set_family(font, node->font_family);
-	pango_font_description_set_absolute_size(font,
-		node->font_size * node->raster_scale * PANGO_SCALE);
-	pango_font_description_set_style(font, to_pango_style(node->font_slant));
-	pango_font_description_set_weight(font,
-		to_pango_weight(node->font_weight));
-	pango_layout_set_font_description(layout, font);
-	pango_font_description_free(font);
-
-	pango_layout_set_text(layout, node->text, -1);
-	pango_layout_set_auto_dir(layout, true);
-	return layout;
-}
-
-static void measure_layout(PangoLayout *layout, struct text_metrics *metrics) {
-	PangoRectangle ink;
-	PangoRectangle logical;
-	pango_layout_get_pixel_extents(layout, &ink, &logical);
-
-	int left = MIN(0, MIN(ink.x, logical.x));
-	int top = MIN(0, MIN(ink.y, logical.y));
-	int right = MAX(ink.x + ink.width, logical.x + logical.width);
-	int bottom = MAX(ink.y + ink.height, logical.y + logical.height);
-	*metrics = (struct text_metrics){
-		.left = left,
-		.top = top,
-		.width = right - left,
-		.height = bottom - top,
-		.baseline = pango_layout_get_baseline(layout) /
-			(double)PANGO_SCALE - top,
-	};
-}
-
 static bool text_node_rasterize(struct wlf_text_node *node) {
 	struct wlf_renderer *renderer = node->renderer;
-	if (renderer == NULL || renderer->impl->texture_from_buffer == NULL) {
+	if (renderer == NULL || renderer->impl->texture_from_buffer == NULL ||
+			node->text_context == NULL) {
 		return false;
 	}
 
-	cairo_surface_t *measure_surface = cairo_image_surface_create(
-		CAIRO_FORMAT_ARGB32, 1, 1);
-	cairo_t *measure = cairo_create(measure_surface);
-	PangoLayout *layout = create_layout(measure, node);
-	struct text_metrics metrics = {0};
-	if (layout != NULL) {
-		measure_layout(layout, &metrics);
-	}
-	bool measured = layout != NULL &&
-		cairo_status(measure) == CAIRO_STATUS_SUCCESS;
-	cairo_destroy(measure);
-	cairo_surface_destroy(measure_surface);
-	if (!measured || metrics.width > INT32_MAX || metrics.height > INT32_MAX) {
+	struct wlf_text_raster raster = {0};
+	if (!wlf_text_rasterize(node->text_context,
+			&(struct wlf_text_options){
+				.text = node->text,
+				.font_family = node->font_family,
+				.font_size = node->font_size,
+				.raster_scale = node->raster_scale,
+				.color = node->color,
+				.max_width = node->max_width,
+				.slant = node->font_slant,
+				.weight = node->font_weight,
+			}, &raster)) {
 		wlf_log(WLF_ERROR, "failed to measure text node");
-		if (layout != NULL) {
-			g_object_unref(layout);
-		}
 		return false;
 	}
 
-	node->natural_width = metrics.width / node->raster_scale;
-	node->baseline = metrics.baseline / node->raster_scale;
-	int width = (int)metrics.width;
-	int height = (int)metrics.height;
-	int max_pixel_width = node->max_width >= 0 ?
-		(int)ceil(node->max_width * node->raster_scale) : -1;
-	if (max_pixel_width >= 0 && width > max_pixel_width) {
-		width = max_pixel_width;
-	}
-	if (node->text[0] == '\0' || width <= 0 || height <= 0) {
-		g_object_unref(layout);
+	node->natural_width = raster.metrics.width / node->raster_scale;
+	node->baseline = raster.metrics.baseline / node->raster_scale;
+	if (node->text[0] == '\0' || raster.width == 0 ||
+			raster.height == 0 || raster.data == NULL || raster.stride == 0) {
+		wlf_text_raster_destroy(node->text_context, &raster);
 		text_node_set_texture(node, NULL);
 		node->base.state.width = 0;
 		node->base.state.height = 0;
@@ -233,48 +154,22 @@ static bool text_node_rasterize(struct wlf_text_node *node) {
 		return true;
 	}
 
-	cairo_surface_t *surface = cairo_image_surface_create(
-		CAIRO_FORMAT_ARGB32, width, height);
-	if (cairo_surface_status(surface) != CAIRO_STATUS_SUCCESS) {
-		wlf_log(WLF_ERROR, "failed to create Cairo text surface: %s",
-			cairo_status_to_string(cairo_surface_status(surface)));
-		g_object_unref(layout);
-		cairo_surface_destroy(surface);
-		return false;
-	}
-
-	cairo_t *cr = cairo_create(surface);
-	cairo_set_operator(cr, CAIRO_OPERATOR_CLEAR);
-	cairo_paint(cr);
-	cairo_set_operator(cr, CAIRO_OPERATOR_OVER);
-	struct wlf_color color = wlf_color_clamp(&node->color);
-	cairo_set_source_rgba(cr, color.r, color.g, color.b, color.a);
-	cairo_move_to(cr, -metrics.left, -metrics.top);
-	pango_cairo_update_layout(cr, layout);
-	pango_cairo_show_layout(cr, layout);
-	bool drawn = cairo_status(cr) == CAIRO_STATUS_SUCCESS;
-	g_object_unref(layout);
-	cairo_destroy(cr);
-	if (!drawn) {
-		wlf_log(WLF_ERROR, "failed to rasterize text node");
-		cairo_surface_destroy(surface);
-		return false;
-	}
-	cairo_surface_flush(surface);
-
+	uint32_t raster_width = raster.width;
+	uint32_t raster_height = raster.height;
 	struct wlf_texture *texture = wlf_texture_from_pixels(renderer,
-		WLF_FORMAT_ARGB8888, cairo_image_surface_get_stride(surface),
-		(uint32_t)width, (uint32_t)height,
-		cairo_image_surface_get_data(surface));
-	cairo_surface_destroy(surface);
+		WLF_FORMAT_ARGB8888, raster.stride, raster.width, raster.height,
+		raster.data);
+	wlf_text_raster_destroy(node->text_context, &raster);
 	if (texture == NULL) {
 		wlf_log(WLF_ERROR, "failed to create renderer texture for text node");
 		return false;
 	}
 
 	text_node_set_texture(node, texture);
-	node->base.state.width = (uint32_t)ceil(width / node->raster_scale);
-	node->base.state.height = (uint32_t)ceil(height / node->raster_scale);
+	node->base.state.width =
+		(uint32_t)ceil(raster_width / node->raster_scale);
+	node->base.state.height =
+		(uint32_t)ceil(raster_height / node->raster_scale);
 	wlf_scene_node_update(&node->base, NULL);
 	return true;
 }
@@ -284,6 +179,7 @@ static void text_node_destroy(struct wlf_scene_node *base) {
 	wlf_linked_list_remove(&node->renderer_destroy.link);
 	wlf_linked_list_remove(&node->window_scale.link);
 	text_node_set_texture(node, NULL);
+	wlf_text_destroy(node->text_context);
 	free(node->font_family);
 	free(node->text);
 	free(node);
@@ -309,7 +205,7 @@ struct wlf_text_node *wlf_text_node_create(struct wlf_scene_node *parent,
 	const char *text_value = text != NULL ? text : "";
 	if (parent == NULL || parent->window == NULL ||
 			parent->window->state.renderer == NULL || font_size <= 0 ||
-			!g_utf8_validate(text_value, -1, NULL)) {
+			!wlf_text_is_valid_utf8(text_value)) {
 		return NULL;
 	}
 
@@ -322,6 +218,14 @@ struct wlf_text_node *wlf_text_node_create(struct wlf_scene_node *parent,
 	node->font_family = strdup(font_family != NULL ?
 		font_family : "sans-serif");
 	if (node->text == NULL || node->font_family == NULL) {
+		free(node->font_family);
+		free(node->text);
+		free(node);
+		return NULL;
+	}
+	node->text_context = wlf_text_autocreate();
+	if (node->text_context == NULL) {
+		wlf_log(WLF_ERROR, "no text implementation is available for this platform");
 		free(node->font_family);
 		free(node->text);
 		free(node);
@@ -352,7 +256,7 @@ void wlf_text_node_set_text(struct wlf_text_node *node, const char *text) {
 		return;
 	}
 	const char *value = text != NULL ? text : "";
-	if (!g_utf8_validate(value, -1, NULL)) {
+	if (!wlf_text_is_valid_utf8(value)) {
 		wlf_log(WLF_ERROR, "text node requires valid UTF-8 text");
 		return;
 	}


### PR DESCRIPTION
Introduce a platform-independent text API for shaping and rasterizing UTF-8 strings with pluggable platform implementations.

Move the existing text rendering code into a Linux Cairo/Pango/HarfBuzz backend and update text nodes to use the new interface. Keep the platform-specific text dependencies out of non-Linux builds.