### PR TITLE
pass: centralize backend pass creation

### DIFF
--- a/include/wlf/pass/wlf_rect_pass.h
+++ b/include/wlf/pass/wlf_rect_pass.h
@@ -68,12 +68,23 @@ struct wlf_rect_pass {
 };
 
 /**
+ * @brief Automatically creates a rectangle rendering pass.
+ *
+ * Selects the pass implementation that matches the renderer backend.
+ *
+ * @param renderer Renderer used to select the pass backend.
+ * @return A newly created rectangle pass, or NULL if the backend is unsupported
+ *         or pass creation fails.
+ */
+struct wlf_rect_pass *wlf_rect_pass_auto_create(struct wlf_renderer *renderer);
+
+/**
  * @brief Initializes a rectangle rendering pass object.
  *
  * @param pass Rectangle pass object to initialize.
  * @param impl Implementation vtable.
  */
-void wlf_render_rect_pass_init(struct wlf_rect_pass *pass,
+void wlf_rect_pass_init(struct wlf_rect_pass *pass,
 	const struct wlf_rect_pass_impl *impl);
 
 /**
@@ -83,7 +94,7 @@ void wlf_render_rect_pass_init(struct wlf_rect_pass *pass,
  *
  * @param pass Rectangle pass object to destroy.
  */
-void wlf_render_rect_pass_destroy(struct wlf_rect_pass *pass);
+void wlf_rect_pass_destroy(struct wlf_rect_pass *pass);
 
 /**
  * @brief Eexecutes a rectangle draw operation within the pass.

--- a/include/wlf/pass/wlf_texture_pass.h
+++ b/include/wlf/pass/wlf_texture_pass.h
@@ -81,6 +81,17 @@ struct wlf_texture_pass {
 };
 
 /**
+ * @brief Automatically creates a texture rendering pass.
+ *
+ * Selects the pass implementation that matches the renderer backend.
+ *
+ * @param renderer Renderer used to select the pass backend.
+ * @return A newly created texture pass, or NULL if the backend is unsupported
+ *         or pass creation fails.
+ */
+struct wlf_texture_pass *wlf_texture_pass_auto_create(struct wlf_renderer *renderer);
+
+/**
  * @brief Initializes a texture pass with backend virtual methods.
  * @param pass Texture pass to initialize.
  * @param impl Backend virtual-method table.

--- a/include/wlf/pass/wlf_vector_pass.h
+++ b/include/wlf/pass/wlf_vector_pass.h
@@ -37,7 +37,7 @@ struct wlf_vector_vertex {
  *
  * Every group of three vertices forms one independent triangle.
  */
-struct wlf_render_vector_options {
+struct wlf_vector_options {
 	const struct wlf_vector_vertex *vertices; /**< Interleaved triangle vertices. */
 	size_t vertex_count; /**< Must be a multiple of three. */
 	struct wlf_color color; /**< Source color before coverage and opacity. */
@@ -72,7 +72,7 @@ struct wlf_vector_pass_impl {
 	 */
 	void (*render)(struct wlf_vector_pass *pass,
 		struct wlf_render_target_info *render_target_info,
-		const struct wlf_render_vector_options *options);
+		const struct wlf_vector_options *options);
 };
 
 /**
@@ -88,18 +88,29 @@ struct wlf_vector_pass {
 };
 
 /**
+ * @brief Automatically creates a vector rendering pass.
+ *
+ * Selects the pass implementation that matches the renderer backend.
+ *
+ * @param renderer Renderer used to select the pass backend.
+ * @return A newly created vector pass, or NULL if the backend is unsupported
+ *         or pass creation fails.
+ */
+struct wlf_vector_pass *wlf_vector_pass_auto_create(struct wlf_renderer *renderer);
+
+/**
  * @brief Initializes a vector pass with backend virtual methods.
  * @param pass Vector pass to initialize.
  * @param impl Backend virtual-method table.
  */
-void wlf_render_vector_pass_init(struct wlf_vector_pass *pass,
+void wlf_vector_pass_init(struct wlf_vector_pass *pass,
 	const struct wlf_vector_pass_impl *impl);
 
 /**
  * @brief Destroys a vector pass and emits its destroy signal.
  * @param pass Vector pass to destroy.
  */
-void wlf_render_vector_pass_destroy(struct wlf_vector_pass *pass);
+void wlf_vector_pass_destroy(struct wlf_vector_pass *pass);
 
 /**
  * @brief Submits a list of independent triangles to the pass.
@@ -109,6 +120,6 @@ void wlf_render_vector_pass_destroy(struct wlf_vector_pass *pass);
  */
 void wlf_render_pass_add_triangles(struct wlf_vector_pass *pass,
 	struct wlf_render_target_info *render_target_info,
-	const struct wlf_render_vector_options *options);
+	const struct wlf_vector_options *options);
 
 #endif // PASS_WLF_VECTOR_PASS_H

--- a/pass/gles/rect_pass.c
+++ b/pass/gles/rect_pass.c
@@ -219,6 +219,6 @@ struct wlf_rect_pass *wlf_gles_rect_pass_create(void) {
 		return NULL;
 	}
 
-	wlf_render_rect_pass_init(&pass->base, &gles_rect_pass_impl);
+	wlf_rect_pass_init(&pass->base, &gles_rect_pass_impl);
 	return &pass->base;
 }

--- a/pass/gles/vector_pass.c
+++ b/pass/gles/vector_pass.c
@@ -89,7 +89,7 @@ static void vector_pass_destroy(struct wlf_vector_pass *base) {
 
 static void vector_pass_render(struct wlf_vector_pass *base,
 		struct wlf_render_target_info *render_target_info,
-		const struct wlf_render_vector_options *options) {
+		const struct wlf_vector_options *options) {
 	struct wlf_gles_vector_pass *pass = wlf_container_of(base, pass, base);
 	if (!wlf_render_target_info_is_gles(render_target_info)) {
 		wlf_log(WLF_ERROR, "GLES vector pass requires a GLES target");
@@ -168,6 +168,6 @@ struct wlf_vector_pass *wlf_gles_vector_pass_create(void) {
 		free(pass);
 		return NULL;
 	}
-	wlf_render_vector_pass_init(&pass->base, &vector_pass_impl);
+	wlf_vector_pass_init(&pass->base, &vector_pass_impl);
 	return &pass->base;
 }

--- a/pass/pixman/rect_pass.c
+++ b/pass/pixman/rect_pass.c
@@ -110,6 +110,6 @@ struct wlf_rect_pass *wlf_pixman_rect_pass_create(void) {
 		return NULL;
 	}
 
-	wlf_render_rect_pass_init(pass, &pixman_rect_pass_impl);
+	wlf_rect_pass_init(pass, &pixman_rect_pass_impl);
 	return pass;
 }

--- a/pass/pixman/vector_pass.c
+++ b/pass/pixman/vector_pass.c
@@ -23,7 +23,7 @@ static void vector_pass_destroy(struct wlf_vector_pass *pass) {
 
 static void vector_pass_render(struct wlf_vector_pass *pass,
 		struct wlf_render_target_info *render_target_info,
-		const struct wlf_render_vector_options *options) {
+		const struct wlf_vector_options *options) {
 	(void)pass;
 	if (!wlf_render_target_info_is_pixman(render_target_info)) {
 		wlf_log(WLF_ERROR, "pixman vector pass requires a pixman target");
@@ -113,6 +113,6 @@ struct wlf_vector_pass *wlf_pixman_vector_pass_create(void) {
 	if (pass == NULL) {
 		return NULL;
 	}
-	wlf_render_vector_pass_init(pass, &vector_pass_impl);
+	wlf_vector_pass_init(pass, &vector_pass_impl);
 	return pass;
 }

--- a/pass/wlf_circle_pass.c
+++ b/pass/wlf_circle_pass.c
@@ -13,7 +13,7 @@ struct wlf_circle_pass *wlf_circle_pass_create(struct wlf_vector_pass *vector_pa
 	if (vector_pass == NULL) return NULL;
 	struct wlf_circle_pass *pass = malloc(sizeof(*pass));
 	if (pass == NULL) {
-		wlf_render_vector_pass_destroy(vector_pass);
+		wlf_vector_pass_destroy(vector_pass);
 		return NULL;
 	}
 	pass->vector = vector_pass;
@@ -22,7 +22,7 @@ struct wlf_circle_pass *wlf_circle_pass_create(struct wlf_vector_pass *vector_pa
 
 void wlf_render_circle_pass_destroy(struct wlf_circle_pass *pass) {
 	if (pass == NULL) return;
-	wlf_render_vector_pass_destroy(pass->vector);
+	wlf_vector_pass_destroy(pass->vector);
 	free(pass);
 }
 

--- a/pass/wlf_ellipse_pass.c
+++ b/pass/wlf_ellipse_pass.c
@@ -13,7 +13,7 @@ struct wlf_ellipse_pass *wlf_ellipse_pass_create(struct wlf_vector_pass *vector_
 	if (vector_pass == NULL) return NULL;
 	struct wlf_ellipse_pass *pass = malloc(sizeof(*pass));
 	if (pass == NULL) {
-		wlf_render_vector_pass_destroy(vector_pass);
+		wlf_vector_pass_destroy(vector_pass);
 		return NULL;
 	}
 	pass->vector = vector_pass;
@@ -22,7 +22,7 @@ struct wlf_ellipse_pass *wlf_ellipse_pass_create(struct wlf_vector_pass *vector_
 
 void wlf_render_ellipse_pass_destroy(struct wlf_ellipse_pass *pass) {
 	if (pass == NULL) return;
-	wlf_render_vector_pass_destroy(pass->vector);
+	wlf_vector_pass_destroy(pass->vector);
 	free(pass);
 }
 

--- a/pass/wlf_line_pass.c
+++ b/pass/wlf_line_pass.c
@@ -9,7 +9,7 @@ struct wlf_line_pass *wlf_line_pass_create(struct wlf_vector_pass *vector_pass) 
 	if (vector_pass == NULL) return NULL;
 	struct wlf_line_pass *pass = malloc(sizeof(*pass));
 	if (pass == NULL) {
-		wlf_render_vector_pass_destroy(vector_pass);
+		wlf_vector_pass_destroy(vector_pass);
 		return NULL;
 	}
 	pass->vector = vector_pass;
@@ -18,7 +18,7 @@ struct wlf_line_pass *wlf_line_pass_create(struct wlf_vector_pass *vector_pass) 
 
 void wlf_render_line_pass_destroy(struct wlf_line_pass *pass) {
 	if (pass == NULL) return;
-	wlf_render_vector_pass_destroy(pass->vector);
+	wlf_vector_pass_destroy(pass->vector);
 	free(pass);
 }
 

--- a/pass/wlf_path_pass.c
+++ b/pass/wlf_path_pass.c
@@ -9,7 +9,7 @@ struct wlf_path_pass *wlf_path_pass_create(struct wlf_vector_pass *vector_pass) 
 	if (vector_pass == NULL) return NULL;
 	struct wlf_path_pass *pass = malloc(sizeof(*pass));
 	if (pass == NULL) {
-		wlf_render_vector_pass_destroy(vector_pass);
+		wlf_vector_pass_destroy(vector_pass);
 		return NULL;
 	}
 	pass->vector = vector_pass;
@@ -18,7 +18,7 @@ struct wlf_path_pass *wlf_path_pass_create(struct wlf_vector_pass *vector_pass) 
 
 void wlf_render_path_pass_destroy(struct wlf_path_pass *pass) {
 	if (pass == NULL) return;
-	wlf_render_vector_pass_destroy(pass->vector);
+	wlf_vector_pass_destroy(pass->vector);
 	free(pass);
 }
 

--- a/pass/wlf_poly_pass.c
+++ b/pass/wlf_poly_pass.c
@@ -9,7 +9,7 @@ struct wlf_poly_pass *wlf_poly_pass_create(struct wlf_vector_pass *vector_pass) 
 	if (vector_pass == NULL) return NULL;
 	struct wlf_poly_pass *pass = malloc(sizeof(*pass));
 	if (pass == NULL) {
-		wlf_render_vector_pass_destroy(vector_pass);
+		wlf_vector_pass_destroy(vector_pass);
 		return NULL;
 	}
 	pass->vector = vector_pass;
@@ -18,7 +18,7 @@ struct wlf_poly_pass *wlf_poly_pass_create(struct wlf_vector_pass *vector_pass) 
 
 void wlf_render_poly_pass_destroy(struct wlf_poly_pass *pass) {
 	if (pass == NULL) return;
-	wlf_render_vector_pass_destroy(pass->vector);
+	wlf_vector_pass_destroy(pass->vector);
 	free(pass);
 }
 

--- a/pass/wlf_rect_pass.c
+++ b/pass/wlf_rect_pass.c
@@ -1,10 +1,34 @@
 #include "wlf/pass/wlf_rect_pass.h"
 #include "wlf/utils/wlf_linked_list.h"
+#include "wlf/config.h"
+#include "wlf/utils/wlf_log.h"
+#include "wlf/renderer/wlf_renderer.h"
+#if WLF_HAS_LINUX_PLATFORM
+#include "wlf/pass/gles/rect_pass.h"
+#include "wlf/pass/pixman/rect_pass.h"
+#include "wlf/renderer/gles/renderer.h"
+#include "wlf/renderer/pixman/renderer.h"
+#endif
 
 #include <assert.h>
 #include <stdlib.h>
 
-void wlf_render_rect_pass_init(struct wlf_rect_pass *pass,
+struct wlf_rect_pass *wlf_rect_pass_auto_create(struct wlf_renderer *renderer) {
+	struct wlf_rect_pass *pass = NULL;
+#if WLF_HAS_LINUX_PLATFORM
+	if (wlf_renderer_is_gles(renderer)) {
+		pass = wlf_gles_rect_pass_create();
+	} else if (wlf_renderer_is_pixman(renderer)) {
+		pass = wlf_pixman_rect_pass_create();
+	} else {
+		wlf_log(WLF_ERROR, "Scene rendering is unsupported by this renderer");
+	}
+#endif
+
+	return pass;
+}
+
+void wlf_rect_pass_init(struct wlf_rect_pass *pass,
 		const struct wlf_rect_pass_impl *impl) {
 	assert(impl->destroy);
 	assert(impl->render);
@@ -15,7 +39,7 @@ void wlf_render_rect_pass_init(struct wlf_rect_pass *pass,
 	wlf_signal_init(&pass->events.destroy);
 }
 
-void wlf_render_rect_pass_destroy(struct wlf_rect_pass *pass) {
+void wlf_rect_pass_destroy(struct wlf_rect_pass *pass) {
 	if (pass == NULL) {
 		return;
 	}

--- a/pass/wlf_rect_shape_pass.c
+++ b/pass/wlf_rect_shape_pass.c
@@ -12,7 +12,7 @@ struct wlf_rect_shape_pass *wlf_rect_shape_pass_create(
 	if (vector_pass == NULL) return NULL;
 	struct wlf_rect_shape_pass *pass = malloc(sizeof(*pass));
 	if (pass == NULL) {
-		wlf_render_vector_pass_destroy(vector_pass);
+		wlf_vector_pass_destroy(vector_pass);
 		return NULL;
 	}
 	pass->vector = vector_pass;
@@ -21,7 +21,7 @@ struct wlf_rect_shape_pass *wlf_rect_shape_pass_create(
 
 void wlf_render_rect_shape_pass_destroy(struct wlf_rect_shape_pass *pass) {
 	if (pass == NULL) return;
-	wlf_render_vector_pass_destroy(pass->vector);
+	wlf_vector_pass_destroy(pass->vector);
 	free(pass);
 }
 

--- a/pass/wlf_shape_geometry.c
+++ b/pass/wlf_shape_geometry.c
@@ -257,7 +257,7 @@ void wlf_shape_submit(struct wlf_vector_pass *pass,
 	if (vertices->failed || vertices->len == 0) return;
 	color.a *= alpha;
 	wlf_render_pass_add_triangles(pass, target,
-		&(struct wlf_render_vector_options){
+		&(struct wlf_vector_options){
 			.vertices = vertices->data,
 			.vertex_count = vertices->len,
 			.color = color,

--- a/pass/wlf_texture_pass.c
+++ b/pass/wlf_texture_pass.c
@@ -1,8 +1,31 @@
 #include "wlf/pass/wlf_texture_pass.h"
 #include "wlf/utils/wlf_linked_list.h"
+#include "wlf/config.h"
+#include "wlf/utils/wlf_log.h"
+#if WLF_HAS_LINUX_PLATFORM
+#include "wlf/pass/gles/texture_pass.h"
+#include "wlf/pass/pixman/texture_pass.h"
+#include "wlf/renderer/gles/renderer.h"
+#include "wlf/renderer/pixman/renderer.h"
+#endif
 
 #include <assert.h>
 #include <stdlib.h>
+
+struct wlf_texture_pass *wlf_texture_pass_auto_create(struct wlf_renderer *renderer) {
+	struct wlf_texture_pass *pass = NULL;
+#if WLF_HAS_LINUX_PLATFORM
+	if (wlf_renderer_is_gles(renderer)) {
+		pass = wlf_gles_texture_pass_create();
+	} else if (wlf_renderer_is_pixman(renderer)) {
+		pass = wlf_pixman_texture_pass_create();
+	} else {
+		wlf_log(WLF_ERROR, "Scene rendering is unsupported by this renderer");
+	}
+#endif
+
+	return pass;
+}
 
 void wlf_render_texture_pass_init(struct wlf_texture_pass *pass,
 		const struct wlf_texture_pass_impl *impl) {

--- a/pass/wlf_vector_pass.c
+++ b/pass/wlf_vector_pass.c
@@ -1,9 +1,32 @@
 #include "wlf/pass/wlf_vector_pass.h"
 #include "wlf/utils/wlf_linked_list.h"
+#include "wlf/config.h"
+#include "wlf/utils/wlf_log.h"
+#if WLF_HAS_LINUX_PLATFORM
+#include "wlf/pass/gles/vector_pass.h"
+#include "wlf/pass/pixman/vector_pass.h"
+#include "wlf/renderer/gles/renderer.h"
+#include "wlf/renderer/pixman/renderer.h"
+#endif
 
 #include <assert.h>
 
-void wlf_render_vector_pass_init(struct wlf_vector_pass *pass,
+struct wlf_vector_pass *wlf_vector_pass_auto_create(struct wlf_renderer *renderer) {
+	struct wlf_vector_pass *pass = NULL;
+#if WLF_HAS_LINUX_PLATFORM
+	if (wlf_renderer_is_gles(renderer)) {
+		return wlf_gles_vector_pass_create();
+	} else if (wlf_renderer_is_pixman(renderer)) {
+		return wlf_pixman_vector_pass_create();
+	} else {
+		wlf_log(WLF_ERROR, "Scene rendering is unsupported by this renderer");
+	}
+#endif
+
+	return pass;
+}
+
+void wlf_vector_pass_init(struct wlf_vector_pass *pass,
 		const struct wlf_vector_pass_impl *impl) {
 	assert(pass != NULL);
 	assert(impl != NULL && impl->destroy != NULL && impl->render != NULL);
@@ -11,7 +34,7 @@ void wlf_render_vector_pass_init(struct wlf_vector_pass *pass,
 	wlf_signal_init(&pass->events.destroy);
 }
 
-void wlf_render_vector_pass_destroy(struct wlf_vector_pass *pass) {
+void wlf_vector_pass_destroy(struct wlf_vector_pass *pass) {
 	if (pass == NULL) {
 		return;
 	}
@@ -22,7 +45,7 @@ void wlf_render_vector_pass_destroy(struct wlf_vector_pass *pass) {
 
 void wlf_render_pass_add_triangles(struct wlf_vector_pass *pass,
 		struct wlf_render_target_info *render_target_info,
-		const struct wlf_render_vector_options *options) {
+		const struct wlf_vector_options *options) {
 	assert(pass != NULL && render_target_info != NULL && options != NULL);
 	assert(options->vertices != NULL && options->vertex_count % 3 == 0);
 	if (options->vertex_count == 0 || options->color.a <= 0) {

--- a/scene/wlf_scene.c
+++ b/scene/wlf_scene.c
@@ -6,17 +6,8 @@
 #include "wlf/pass/wlf_path_pass.h"
 #include "wlf/pass/wlf_poly_pass.h"
 #include "wlf/pass/wlf_rect_shape_pass.h"
-#include "wlf/pass/gles/rect_pass.h"
-#include "wlf/pass/gles/texture_pass.h"
-#include "wlf/pass/gles/vector_pass.h"
-#include "wlf/pass/pixman/rect_pass.h"
-#include "wlf/pass/pixman/texture_pass.h"
-#include "wlf/pass/pixman/vector_pass.h"
-#include "wlf/config.h"
-#if WLF_HAS_LINUX_PLATFORM
-#include "wlf/renderer/gles/renderer.h"
-#include "wlf/renderer/pixman/renderer.h"
-#endif
+#include "wlf/pass/wlf_rect_pass.h"
+#include "wlf/pass/wlf_texture_pass.h"
 #include "wlf/scene/wlf_scene_tree.h"
 #include "wlf/utils/wlf_log.h"
 #include "wlf/utils/wlf_env.h"
@@ -117,40 +108,17 @@ static void render_damage_highlights(struct wlf_scene *scene,
 	}
 }
 
-static struct wlf_vector_pass *create_vector_pass(
-		struct wlf_renderer *renderer) {
-#if WLF_HAS_LINUX_PLATFORM
-	if (wlf_renderer_is_gles(renderer)) {
-		return wlf_gles_vector_pass_create();
-	}
-	if (wlf_renderer_is_pixman(renderer)) {
-		return wlf_pixman_vector_pass_create();
-	}
-#endif
-	return NULL;
-}
-
 static bool create_passes(struct wlf_scene *scene) {
 	struct wlf_renderer *renderer = scene->window->state.renderer;
-#if WLF_HAS_LINUX_PLATFORM
-	if (wlf_renderer_is_gles(renderer)) {
-		scene->rect_pass = wlf_gles_rect_pass_create();
-		scene->texture_pass = wlf_gles_texture_pass_create();
-	} else if (wlf_renderer_is_pixman(renderer)) {
-		scene->rect_pass = wlf_pixman_rect_pass_create();
-		scene->texture_pass = wlf_pixman_texture_pass_create();
-	} else {
-		wlf_log(WLF_ERROR, "Scene rendering is unsupported by this renderer");
-		return false;
-	}
-#endif
+	scene->rect_pass = wlf_rect_pass_auto_create(renderer);
+	scene->texture_pass = wlf_texture_pass_auto_create(renderer);
 	scene->rect_shape_pass = wlf_rect_shape_pass_create(
-		create_vector_pass(renderer));
-	scene->circle_pass = wlf_circle_pass_create(create_vector_pass(renderer));
-	scene->ellipse_pass = wlf_ellipse_pass_create(create_vector_pass(renderer));
-	scene->line_pass = wlf_line_pass_create(create_vector_pass(renderer));
-	scene->poly_pass = wlf_poly_pass_create(create_vector_pass(renderer));
-	scene->path_pass = wlf_path_pass_create(create_vector_pass(renderer));
+		wlf_vector_pass_auto_create(renderer));
+	scene->circle_pass = wlf_circle_pass_create(wlf_vector_pass_auto_create(renderer));
+	scene->ellipse_pass = wlf_ellipse_pass_create(wlf_vector_pass_auto_create(renderer));
+	scene->line_pass = wlf_line_pass_create(wlf_vector_pass_auto_create(renderer));
+	scene->poly_pass = wlf_poly_pass_create(wlf_vector_pass_auto_create(renderer));
+	scene->path_pass = wlf_path_pass_create(wlf_vector_pass_auto_create(renderer));
 
 	return scene->rect_pass != NULL && scene->texture_pass != NULL &&
 		scene->rect_shape_pass != NULL && scene->circle_pass != NULL &&
@@ -166,7 +134,7 @@ static void destroy_passes(struct wlf_scene *scene) {
 	wlf_render_circle_pass_destroy(scene->circle_pass);
 	wlf_render_rect_shape_pass_destroy(scene->rect_shape_pass);
 	wlf_render_texture_pass_destroy(scene->texture_pass);
-	wlf_render_rect_pass_destroy(scene->rect_pass);
+	wlf_rect_pass_destroy(scene->rect_pass);
 }
 
 static struct wlf_render_target_info *configure_render_target(
@@ -562,16 +530,6 @@ static bool scene_build_state(struct wlf_scene *scene,
 	}
 	pixman_region32_union(&render_damage, &state->damage,
 		&scene->previous_damage);
-#if WLF_HAS_LINUX_PLATFORM
-	/* EGL does not expose a stable buffer identity here. Without EGL buffer-age
-	 * tracking, repaint the whole back buffer while still presenting only the
-	 * actual surface damage. */
-	if (wlf_renderer_is_gles(window->state.renderer)) {
-		pixman_region32_clear(&render_damage);
-		pixman_region32_union_rect(&render_damage, &render_damage,
-			0, 0, width, height);
-	}
-#endif
 	if (!scene_build_render_list(scene, width, height)) {
 		pixman_region32_fini(&render_damage);
 		return false;


### PR DESCRIPTION
Add automatic constructors for rectangle, texture, and vector passes so backend selection is handled by the generic pass layer instead of the scene.

Rename pass lifecycle functions and vector rendering options to use consistent names, and update the scene and backend implementations accordingly.