### PR TITLE
image/wlf_image: initialize destruction listener state

### DIFF
--- a/image/wlf_image.c
+++ b/image/wlf_image.c
@@ -19,12 +19,14 @@ void wlf_image_init(struct wlf_image *image,
 
 	*image = (struct wlf_image) {
 		.impl = impl,
+		.listener = NULL,
+		.user_data = NULL,
 		.width = width,
 		.height = height,
 		.format = format,
+		.has_alpha_channel = false,
+		.is_opaque = false,
 	};
-	image->has_alpha_channel = false;
-	image->is_opaque = false;
 }
 
 void wlf_image_add_listener(struct wlf_image *image,

--- a/include/wlf/shapes/wlf_shape.h
+++ b/include/wlf/shapes/wlf_shape.h
@@ -15,7 +15,6 @@
 #ifndef SHAPES_WLF_SHAPE_H
 #define SHAPES_WLF_SHAPE_H
 
-#include "wlf/utils/wlf_signal.h"
 #include "wlf/utils/wlf_linked_list.h"
 #include "wlf/types/wlf_color.h"
 


### PR DESCRIPTION
Initialize the listener and user data fields in wlf_image_init() so images without a registered listener can be destroyed safely.