### PR TITLE
allocator: remove wlf_allocator_autocreate

### DIFF
--- a/allocator/wlf_allocator.c
+++ b/allocator/wlf_allocator.c
@@ -1,10 +1,4 @@
 #include "wlf/allocator/wlf_allocator.h"
-#include "wlf/config.h"
-#if WLF_HAS_LINUX_PLATFORM
-#include "wlf/allocator/shm/allocator.h"
-#include "wlf/platform/wayland/backend.h"
-#include "wlf/renderer/pixman/renderer.h"
-#endif
 
 #include <assert.h>
 #include <stdlib.h>
@@ -17,23 +11,6 @@ void wlf_allocator_init(struct wlf_allocator *allocator,
 	allocator->impl = impl;
 
 	wlf_signal_init(&allocator->events.destroy);
-}
-
-struct wlf_allocator *wlf_allocator_autocreate(struct wlf_backend *backend,
-		struct wlf_renderer *renderer) {
-#if WLF_HAS_LINUX_PLATFORM
-	if (wlf_backend_is_wayland(backend)) {
-		if (wlf_renderer_is_pixman(renderer)) {
-			struct wlf_wl_backend *wl_backend =
-				wlf_wl_backend_from_backend(backend);
-			return wlf_shm_allocator_create(wl_backend->wl_shm.shm);
-		}
-	}
-
-	return NULL;
-#endif
-
-	return NULL;
 }
 
 void wlf_allocator_destroy(struct wlf_allocator *allocator) {

--- a/include/wlf/allocator/wlf_allocator.h
+++ b/include/wlf/allocator/wlf_allocator.h
@@ -17,8 +17,6 @@
 
 #include "wlf/utils/wlf_signal.h"
 #include "wlf/buffer/wlf_buffer.h"
-#include "wlf/platform/wlf_backend.h"
-#include "wlf/renderer/wlf_renderer.h"
 #include "wlf//types/wlf_format_set.h"
 
 struct wlf_allocator;
@@ -65,16 +63,6 @@ struct wlf_allocator {
  */
 void wlf_allocator_init(struct wlf_allocator *allocator,
 	const struct wlf_allocator_impl *impl);
-
-/**
- * @brief Automatically creates a suitable allocator for backend and renderer.
- *
- * @param backend Backend used by this allocator.
- * @param renderer Renderer used by this allocator.
- * @return Created allocator instance, or NULL when unavailable.
- */
-struct wlf_allocator *wlf_allocator_autocreate(struct wlf_backend *backend,
-	struct wlf_renderer *renderer);
 
 /**
  * @brief Destroys an allocator object.


### PR DESCRIPTION
Allocator creation is now handled by the swapchain, so the backend/renderer-based autocreate helper is no longer needed.