### PR TITLE
allocator/egl: return the concrete allocator

### DIFF
--- a/allocator/egl/allocator.c
+++ b/allocator/egl/allocator.c
@@ -26,7 +26,7 @@ static const struct wlf_allocator_impl allocator_impl = {
 	.create_buffer = allocator_create_buffer,
 };
 
-struct wlf_allocator *wlf_egl_allocator_create(struct wlf_egl *egl,
+struct wlf_egl_allocator *wlf_egl_allocator_create(struct wlf_egl *egl,
 		struct wl_surface *surface) {
 	if (egl == NULL || surface == NULL) {
 		return NULL;
@@ -41,7 +41,8 @@ struct wlf_allocator *wlf_egl_allocator_create(struct wlf_egl *egl,
 	allocator->egl = egl;
 	allocator->surface = surface;
 	wlf_allocator_init(&allocator->base, &allocator_impl);
-	return &allocator->base;
+
+	return allocator;
 }
 
 bool wlf_allocator_is_egl(const struct wlf_allocator *allocator) {

--- a/include/wlf/allocator/egl/allocator.h
+++ b/include/wlf/allocator/egl/allocator.h
@@ -37,9 +37,9 @@ struct wlf_egl_allocator {
  * @brief Creates an EGL window-surface allocator.
  * @param egl EGL context used for surface creation.
  * @param surface Native Wayland surface receiving the EGL window.
- * @return Newly allocated generic allocator, or NULL on failure.
+ * @return Newly allocated egl allocator, or NULL on failure.
  */
-struct wlf_allocator *wlf_egl_allocator_create(struct wlf_egl *egl,
+struct wlf_egl_allocator *wlf_egl_allocator_create(struct wlf_egl *egl,
 	struct wl_surface *surface);
 
 /**

--- a/swapchain/egl/swapchain.c
+++ b/swapchain/egl/swapchain.c
@@ -127,12 +127,14 @@ struct wlf_swapchain *wlf_egl_swapchain_create(struct wlf_window *window,
 		return NULL;
 	}
 
-	struct wlf_allocator *allocator =
+	struct wlf_egl_allocator *egl_allocator =
 		wlf_egl_allocator_create(gles_renderer->egl, surface);
-	if (allocator == NULL) {
+	if (egl_allocator == NULL) {
 		free(swapchain);
 		return NULL;
 	}
+
+	struct wlf_allocator *allocator = &egl_allocator->base;
 #else
 	free(swapchain);
 	return NULL;


### PR DESCRIPTION
Return the EGL-specific allocator from
wlf_egl_allocator_create() so the EGL swapchain can retain its concrete type while passing the embedded generic allocator onward.