### PR TITLE
allocator/shm: return the concrete allocator

### DIFF
--- a/allocator/shm/allocator.c
+++ b/allocator/shm/allocator.c
@@ -37,7 +37,7 @@ static const struct wlf_allocator_impl allocator_impl = {
 	.create_buffer = allocator_create_buffer,
 };
 
-struct wlf_allocator *wlf_shm_allocator_create(struct wl_shm *wl_shm) {
+struct wlf_shm_allocator *wlf_shm_allocator_create(struct wl_shm *wl_shm) {
 	struct wlf_shm_allocator *allocator = calloc(1, sizeof(*allocator));
 	if (allocator == NULL) {
 		wlf_log_errno(WLF_ERROR, "failed to allocate wlf_shm_allocator");
@@ -47,7 +47,7 @@ struct wlf_allocator *wlf_shm_allocator_create(struct wl_shm *wl_shm) {
 	allocator->wl_shm = wl_shm;
 	wlf_allocator_init(&allocator->base, &allocator_impl);
 
-	return &allocator->base;
+	return allocator;
 }
 
 bool wlf_allocator_is_shm(const struct wlf_allocator *allocator) {

--- a/include/wlf/allocator/shm/allocator.h
+++ b/include/wlf/allocator/shm/allocator.h
@@ -42,7 +42,7 @@ struct wlf_shm_allocator {
  * @param wl_shm Wayland shared memory global to use for buffer creation.
  * @return Pointer to the created allocator, or NULL on failure.
  */
-struct wlf_allocator *wlf_shm_allocator_create(struct wl_shm *wl_shm);
+struct wlf_shm_allocator *wlf_shm_allocator_create(struct wl_shm *wl_shm);
 
 /**
  * @brief Checks if an allocator is a SHM allocator.

--- a/swapchain/shm/swapchain.c
+++ b/swapchain/shm/swapchain.c
@@ -107,12 +107,13 @@ struct wlf_swapchain *wlf_shm_swapchain_create(struct wlf_window *window,
 	}
 
 	struct wlf_wl_backend *wl_backend = wlf_wl_backend_from_backend(window->state.backend);
-	struct wlf_allocator *allocator = wlf_shm_allocator_create(wl_backend->wl_shm.shm);
-	if (allocator == NULL) {
+	struct wlf_shm_allocator *shm_allocator = wlf_shm_allocator_create(wl_backend->wl_shm.shm);
+	if (shm_allocator == NULL) {
 		free(swapchain);
 		return NULL;
 	}
 
+	struct wlf_allocator *allocator = &shm_allocator->base;
 	wlf_swapchain_init(&swapchain->base, allocator, &swapchain_impl, width, height);
 	if (!wlf_render_format_copy(&swapchain->base.format, format)) {
 		wlf_swapchain_destroy(&swapchain->base);


### PR DESCRIPTION
Return the SHM-specific allocator from
wlf_shm_allocator_create() so the SHM swapchain can use its embedded generic allocator.