### PR TITLE
curve: fix header guard prefixes

### DIFF
--- a/include/wlf/curve/curve_helpers.h
+++ b/include/wlf/curve/curve_helpers.h
@@ -11,8 +11,8 @@
  *      version: v1.0, YaoBing Xiao, 2026-02-02, initial version\n
  */
 
-#ifndef ANIMATOR_CURVE_HELPERS_H
-#define ANIMATOR_CURVE_HELPERS_H
+#ifndef CURVE_CURVE_HELPERS_H
+#define CURVE_CURVE_HELPERS_H
 
 #include <math.h>
 
@@ -52,4 +52,4 @@ static inline float clamp_t(float t) {
 	return t;
 }
 
-#endif // ANIMATOR_CURVE_HELPERS_H
+#endif // CURVE_CURVE_HELPERS_H

--- a/include/wlf/curve/easing_functions.h
+++ b/include/wlf/curve/easing_functions.h
@@ -14,8 +14,8 @@
  *      version: v1.0, YaoBing Xiao, 2026-02-02, initial version\n
  */
 
-#ifndef ANIMATOR_EASING_FUNCTIONS_H
-#define ANIMATOR_EASING_FUNCTIONS_H
+#ifndef CURVE_EASING_FUNCTIONS_H
+#define CURVE_EASING_FUNCTIONS_H
 
 #include <math.h>
 
@@ -504,4 +504,4 @@ static inline float ease_in_out_bounce(float t) {
 	return ease_out_bounce(t * 2.0f - 1.0f) * 0.5f + 0.5f;
 }
 
-#endif // ANIMATOR_EASING_FUNCTIONS_H
+#endif // CURVE_EASING_FUNCTIONS_H

--- a/include/wlf/curve/wlf_curve.h
+++ b/include/wlf/curve/wlf_curve.h
@@ -14,8 +14,8 @@
  *      version: v1.0, YaoBing Xiao, 2026-01-31, initial version\n
  */
 
-#ifndef ANIMATOR_WLF_CURVE_H
-#define ANIMATOR_WLF_CURVE_H
+#ifndef CURVE_WLF_CURVE_H
+#define CURVE_WLF_CURVE_H
 
 struct wlf_curve;
 
@@ -113,4 +113,4 @@ void wlf_curve_destroy(struct wlf_curve *curve);
 void wlf_curve_add_listener(struct wlf_curve *curve,
 	const struct wlf_curve_listener *listener, void *data);
 
-#endif // ANIMATOR_WLF_CURVE_H
+#endif // CURVE_WLF_CURVE_H

--- a/include/wlf/curve/wlf_curve_back.h
+++ b/include/wlf/curve/wlf_curve_back.h
@@ -14,8 +14,8 @@
  *      version: v1.0, YaoBing Xiao, 2026-02-02, initial version\n
  */
 
-#ifndef ANIMATOR_WLF_CURVE_BACK_H
-#define ANIMATOR_WLF_CURVE_BACK_H
+#ifndef CURVE_WLF_CURVE_BACK_H
+#define CURVE_WLF_CURVE_BACK_H
 
 #include <stdbool.h>
 
@@ -111,4 +111,4 @@ bool wlf_curve_is_back(const struct wlf_curve *curve);
 struct wlf_curve_back *wlf_curve_back_from_curve(
 	struct wlf_curve *curve);
 
-#endif // ANIMATOR_WLF_CURVE_BACK_H
+#endif // CURVE_WLF_CURVE_BACK_H

--- a/include/wlf/curve/wlf_curve_bounce.h
+++ b/include/wlf/curve/wlf_curve_bounce.h
@@ -13,8 +13,8 @@
  *      version: v1.0, YaoBing Xiao, 2026-02-11, initial version\n
  */
 
-#ifndef ANIMATOR_WLF_CURVE_BOUNCE_H
-#define ANIMATOR_WLF_CURVE_BOUNCE_H
+#ifndef CURVE_WLF_CURVE_BOUNCE_H
+#define CURVE_WLF_CURVE_BOUNCE_H
 
 #include "wlf/curve/wlf_curve.h"
 
@@ -102,4 +102,4 @@ bool wlf_curve_is_bounce(const struct wlf_curve *curve);
 struct wlf_curve_bounce *wlf_curve_bounce_from_curve(
 	struct wlf_curve *curve);
 
-#endif // ANIMATOR_WLF_CURVE_BOUNCE_H
+#endif // CURVE_WLF_CURVE_BOUNCE_H

--- a/include/wlf/curve/wlf_curve_circ.h
+++ b/include/wlf/curve/wlf_curve_circ.h
@@ -13,8 +13,8 @@
  *      version: v1.0, YaoBing Xiao, 2026-02-11, initial version\n
  */
 
-#ifndef ANIMATOR_WLF_CURVE_CIRC_H
-#define ANIMATOR_WLF_CURVE_CIRC_H
+#ifndef CURVE_WLF_CURVE_CIRC_H
+#define CURVE_WLF_CURVE_CIRC_H
 
 #include "wlf/curve/wlf_curve.h"
 
@@ -101,4 +101,4 @@ bool wlf_curve_is_circ(const struct wlf_curve *curve);
 struct wlf_curve_circ *wlf_curve_circ_from_curve(
 	struct wlf_curve *curve);
 
-#endif // ANIMATOR_WLF_CURVE_CIRC_H
+#endif // CURVE_WLF_CURVE_CIRC_H

--- a/include/wlf/curve/wlf_curve_cubic.h
+++ b/include/wlf/curve/wlf_curve_cubic.h
@@ -14,8 +14,8 @@
  *      version: v1.0, YaoBing Xiao, 2026-02-12, initial version\n
  */
 
-#ifndef ANIMATOR_WLF_CURVE_CUBIC_H
-#define ANIMATOR_WLF_CURVE_CUBIC_H
+#ifndef CURVE_WLF_CURVE_CUBIC_H
+#define CURVE_WLF_CURVE_CUBIC_H
 
 #include "wlf/curve/wlf_curve.h"
 
@@ -102,4 +102,4 @@ bool wlf_curve_is_cubic(const struct wlf_curve *curve);
 struct wlf_curve_cubic *wlf_curve_cubic_from_curve(
 	struct wlf_curve *curve);
 
-#endif // ANIMATOR_WLF_CURVE_CUBIC_H
+#endif // CURVE_WLF_CURVE_CUBIC_H

--- a/include/wlf/curve/wlf_curve_elastic.h
+++ b/include/wlf/curve/wlf_curve_elastic.h
@@ -15,8 +15,8 @@
  *      version: v1.0, YaoBing Xiao, 2026-02-12, initial version\n
  */
 
-#ifndef ANIMATOR_WLF_CURVE_ELASTIC_H
-#define ANIMATOR_WLF_CURVE_ELASTIC_H
+#ifndef CURVE_WLF_CURVE_ELASTIC_H
+#define CURVE_WLF_CURVE_ELASTIC_H
 
 #include "wlf/curve/wlf_curve.h"
 
@@ -122,4 +122,4 @@ bool wlf_curve_is_elastic(const struct wlf_curve *curve);
 struct wlf_curve_elastic *wlf_curve_elastic_from_curve(
 	struct wlf_curve *curve);
 
-#endif // ANIMATOR_WLF_CURVE_ELASTIC_H
+#endif // CURVE_WLF_CURVE_ELASTIC_H

--- a/include/wlf/curve/wlf_curve_expo.h
+++ b/include/wlf/curve/wlf_curve_expo.h
@@ -16,8 +16,8 @@
  *      version: v1.0, YaoBing Xiao, 2026-02-12, initial version\n
  */
 
-#ifndef ANIMATOR_WLF_CURVE_EXPO_H
-#define ANIMATOR_WLF_CURVE_EXPO_H
+#ifndef CURVE_WLF_CURVE_EXPO_H
+#define CURVE_WLF_CURVE_EXPO_H
 
 #include "wlf/curve/wlf_curve.h"
 
@@ -104,4 +104,4 @@ bool wlf_curve_is_expo(const struct wlf_curve *curve);
 struct wlf_curve_expo *wlf_curve_expo_from_curve(
 	struct wlf_curve *curve);
 
-#endif // ANIMATOR_WLF_CURVE_EXPO_H
+#endif // CURVE_WLF_CURVE_EXPO_H

--- a/include/wlf/curve/wlf_curve_linear.h
+++ b/include/wlf/curve/wlf_curve_linear.h
@@ -13,8 +13,8 @@
  *      version: v1.0, YaoBing Xiao, 2026-02-12, initial version\n
  */
 
-#ifndef ANIMATOR_WLF_CURVE_LINEAR_H
-#define ANIMATOR_WLF_CURVE_LINEAR_H
+#ifndef CURVE_WLF_CURVE_LINEAR_H
+#define CURVE_WLF_CURVE_LINEAR_H
 
 #include "wlf/curve/wlf_curve.h"
 
@@ -70,4 +70,4 @@ bool wlf_curve_is_linear(const struct wlf_curve *curve);
 struct wlf_curve_linear *wlf_curve_linear_from_curve(
 	struct wlf_curve *curve);
 
-#endif // ANIMATOR_WLF_CURVE_LINEAR_H
+#endif // CURVE_WLF_CURVE_LINEAR_H

--- a/include/wlf/curve/wlf_curve_quad.h
+++ b/include/wlf/curve/wlf_curve_quad.h
@@ -14,8 +14,8 @@
  *      version: v1.0, YaoBing Xiao, 2026-02-12, initial version\n
  */
 
-#ifndef ANIMATOR_WLF_CURVE_QUAD_H
-#define ANIMATOR_WLF_CURVE_QUAD_H
+#ifndef CURVE_WLF_CURVE_QUAD_H
+#define CURVE_WLF_CURVE_QUAD_H
 
 #include "wlf/curve/wlf_curve.h"
 
@@ -102,4 +102,4 @@ bool wlf_curve_is_quad(const struct wlf_curve *curve);
 struct wlf_curve_quad *wlf_curve_quad_from_curve(
 	struct wlf_curve *curve);
 
-#endif // ANIMATOR_WLF_CURVE_QUAD_H
+#endif // CURVE_WLF_CURVE_QUAD_H

--- a/include/wlf/curve/wlf_curve_quart.h
+++ b/include/wlf/curve/wlf_curve_quart.h
@@ -14,8 +14,8 @@
  *      version: v1.0, YaoBing Xiao, 2026-02-12, initial version\n
  */
 
-#ifndef ANIMATOR_WLF_CURVE_QUART_H
-#define ANIMATOR_WLF_CURVE_QUART_H
+#ifndef CURVE_WLF_CURVE_QUART_H
+#define CURVE_WLF_CURVE_QUART_H
 
 #include "wlf/curve/wlf_curve.h"
 
@@ -102,4 +102,4 @@ bool wlf_curve_is_quart(const struct wlf_curve *curve);
 struct wlf_curve_quart *wlf_curve_quart_from_curve(
 	struct wlf_curve *curve);
 
-#endif // ANIMATOR_WLF_CURVE_QUART_H
+#endif // CURVE_WLF_CURVE_QUART_H

--- a/include/wlf/curve/wlf_curve_quint.h
+++ b/include/wlf/curve/wlf_curve_quint.h
@@ -14,8 +14,8 @@
  *      version: v1.0, YaoBing Xiao, 2026-02-13, initial version\n
  */
 
-#ifndef ANIMATOR_WLF_CURVE_QUINT_H
-#define ANIMATOR_WLF_CURVE_QUINT_H
+#ifndef CURVE_WLF_CURVE_QUINT_H
+#define CURVE_WLF_CURVE_QUINT_H
 
 #include "wlf/curve/wlf_curve.h"
 
@@ -102,4 +102,4 @@ bool wlf_curve_is_quint(const struct wlf_curve *curve);
 struct wlf_curve_quint *wlf_curve_quint_from_curve(
 	struct wlf_curve *curve);
 
-#endif // ANIMATOR_WLF_CURVE_QUINT_H
+#endif // CURVE_WLF_CURVE_QUINT_H

--- a/include/wlf/curve/wlf_curve_sine.h
+++ b/include/wlf/curve/wlf_curve_sine.h
@@ -14,8 +14,8 @@
  *      version: v1.0, YaoBing Xiao, 2026-02-13, initial version\n
  */
 
-#ifndef ANIMATOR_WLF_CURVE_SINE_H
-#define ANIMATOR_WLF_CURVE_SINE_H
+#ifndef CURVE_WLF_CURVE_SINE_H
+#define CURVE_WLF_CURVE_SINE_H
 
 #include "wlf/curve/wlf_curve.h"
 
@@ -102,4 +102,4 @@ bool wlf_curve_is_sine(const struct wlf_curve *curve);
 struct wlf_curve_sine *wlf_curve_sine_from_curve(
 	struct wlf_curve *curve);
 
-#endif // ANIMATOR_WLF_CURVE_SINE_H
+#endif // CURVE_WLF_CURVE_SINE_H


### PR DESCRIPTION
Replace the stale ANIMATOR prefix with CURVE so the header guards match the curve subsystem name.